### PR TITLE
Nttableclarifylabels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# pvDataWWW
+
+pvDataWWW is the repository of the files making up the EPICS Version 4 web site at
+http://epics-pvdata.sourceforge.net.
+

--- a/mainPage/alpha/normativeTypes/normativeTypes.html
+++ b/mainPage/alpha/normativeTypes/normativeTypes.html
@@ -3,7 +3,9 @@
       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!--
 Auth:  Greg White, SLAC, Nov-2011.
-Vers:  12-May-2015, Dave Hickin
+Vers:  12-Aug-2015, Greg White
+       Minor clarifications to aspects of NTTable
+       12-May-2015, Dave Hickin
        Reorder optional fields to be consistent with pvData and normativeTypesCPP.
        Added  NTScalarMultiChannel. Made doc more consistent. Minor corrections.
        16-Mar-2015, Dave Hickin
@@ -1537,16 +1539,17 @@ indexed element of the <span class="term">value</span> array. </p>
 
 <h3>NTTable</h3>
 
-<p>NTTable is the EPICS V4 Normative Type for "2-d" tabular datasets.</p>
+<p>NTTable is the EPICS V4 Normative Type suitable for column-oriented tabular datasets.</p>
 
-<p>An NTTable is made up of a number of arrays, each array being of a scalar
-type. Each array can be thought of as a column. Each <em>i</em>th array member makes
-up one row, or n-tuple.</p>
+<p>An NTTable is made up of a number of arrays. Each array can be thought of as a column.
+Each array MUST be of a scalar type. Each array may be of a different scalar type, though
+all the arrays MUST be of the same length. The set of the <em>i</em>th array members of
+all the columns makes up one row, or n-tuple. </p>
 
-<p>Use case examples: a table of Twiss parameters of all lattice elements in an
-accelerator section. Another example, where the columns might vary call-to-call would
+<p>Use case examples: a table of the Twiss parameters of all the lattice elements in an
+accelerator section. Another example, where the columns might vary call-to-call to an RPC setting, would
 be that of an EPICS V4 SQL database service. In that example one NTTable returned by
-the service would contain all the tabular results of a SQL SELECT, essentially a
+the service would contain the tabular results of a SQL SELECT, essentially a
 recoded JDBC or ODBC ResultSet - see the <a class="bib"
 href="#bib:rdbservice">rdbservice</a>.
 </p>
@@ -1566,33 +1569,30 @@ structure
 <p>where:</p>
 <dl>
   <dt>labels</dt>
-    <dd>The table column headings of each column, each heading given as one element
-      of the array of strings. The order of labels MUST match the intended order of the
-      <span class="nterm">scalar_t[]</span> data.
+  <dd>The table column headings are given by the <span class="term">labels</span> field.
+      Each column heading given as one element of the array of strings.
     </dd>
     <dt>value</dt>
-    <dd>The data of the table are encoded in a structure named "value" (that is,
-    the pvData binding, whose field name is "value"). We call the columnar data Field
-    "value" (rather than for instance "columndata") so that the primary field of the
+    <dd>The data of the table are encoded in a structure named <span class="term">value</span>. We call the columnar data field
+    "value" (rather than, for instance, "columndata") so that the primary field of the
       type is named the same for all Normative Types, and so to help general purpose clients
       identify the primary field.</dd>
 </dl>
 
 <h4>Interpretation</h4>
 
-<p>This represents a table. The number of "columns" is equal to the number of fields
-which follows field "labels." Each <span class="user">colname</span> scalar array
-field contains the data for the "column" corresponding to the same indexed element of
-the <span class="term">labels</span> field.  The value of each element of <span
-class="term">labels</span> SHOULD be used as a column heading for the corresponding
-<span class="user">colname</span> field.</p>
+<p>This represents a table of data. The column data is given in scalar arrays in the structure field <span class="term">value</span>, and the column headings are given in field <span class="term">labels</span>. The number of elements of <span class="term">labels</span> MUST be equal to the
+number of fields of <span class="term">value</span>. Each <span class="user">colname</span> scalar array
+field of <span class="term">value</span> contains the data for the column corresponding to the same indexed element of
+the <span class="term">labels</span> field.  Agents SHOULD use the elements of <span
+class="term">labels</span> as the column headings. <span class="nonnorm">There is no normative requirement that the
+field names of <span class="term">value</span> match the strings in <span class="term">labels</span>, though doing so is fine</span>. </p>
 
 <p>Note that the above description is given in terms of a table and its columns,
 but there is nothing specifically columnar about how this data may be rendered. A
-user may choose to print the fields row wise. For instance, if there are many fields,
-but each has only length 1 or 2. E.g., if you wanted to give all the scalar data related
-to one device, then you might use an NTTable rendered in such a way. Note that one column
-of a table would also be easily described by NTNameValue.
+user may choose to print the fields row wise. For instance, if there are many fields in <span class="term">value</span>,
+but each has only length 1 or 2. For instance, if you wanted to give all the scalar data related
+to one device, then you might use an NTTable rendered in such a way.
 </p>
 
 <h4>Validation</h4>

--- a/mainPage/alpha/normativeTypes/normativeTypes.html
+++ b/mainPage/alpha/normativeTypes/normativeTypes.html
@@ -140,8 +140,9 @@ here, named "NTTable", defines a structure for expressing (in <a
       <h2 class="nocount">Status of this Document</h2>
       <!-- Statement about why this version exists -->
       
-      <p>This is the 16 Mar 2015 version of the Normative Types document.
-       This version updates the definitions of time_t, control_t, display_t,
+      <p>This is the 16 Mar 2015 version of the Normative Types document, with the addition
+       of minor clarifications to the dscription of NTTable. The 16 Mar 2015 version
+       updates the definitions of time_t, control_t, display_t,
        and alarmLimit_t and changes the order of optional fields in a
        number of Normative Types.</p>
        
@@ -1541,18 +1542,19 @@ indexed element of the <span class="term">value</span> array. </p>
 
 <p>NTTable is the EPICS V4 Normative Type suitable for column-oriented tabular datasets.</p>
 
-<p>An NTTable is made up of a number of arrays. Each array can be thought of as a column.
-Each array MUST be of a scalar type. Each array may be of a different scalar type, though
-all the arrays MUST be of the same length. The set of the <em>i</em>th array members of
-all the columns makes up one row, or n-tuple. </p>
+<p>An NTTable is made up of a number of arrays. Each array can be thought of as a
+column. Each array MUST be of a scalar type and all the arrays MUST be of the same
+length. Each array may be of a different scalar type. The set of the <em>i</em>th array
+members of all the columns make up one row, or n-tuple. The number of elements of <span
+class="term">labels</span> MUST be equal to the number of fields of <span
+class="term">value</span>.</p>
 
 <p>Use case examples: a table of the Twiss parameters of all the lattice elements in an
-accelerator section. Another example, where the columns might vary call-to-call to an RPC setting, would
-be that of an EPICS V4 SQL database service. In that example one NTTable returned by
-the service would contain the tabular results of a SQL SELECT, essentially a
-recoded JDBC or ODBC ResultSet - see the <a class="bib"
-href="#bib:rdbservice">rdbservice</a>.
-</p>
+accelerator section. Another example, where the columns might vary call-to-call to an
+RPC setting, would be that of an EPICS V4 SQL database service. In that example one
+NTTable returned by the service would contain the tabular results of a SQL SELECT,
+essentially a recoded JDBC or ODBC ResultSet - see the <a class="bib"
+href="#bib:rdbservice">rdbservice</a>. </p>
 
 <pre><span class="nterm">NTTable</span> := 
 
@@ -1581,18 +1583,17 @@ structure
 
 <h4>Interpretation</h4>
 
-<p>This represents a table of data. The column data is given in scalar arrays in the structure field <span class="term">value</span>, and the column headings are given in field <span class="term">labels</span>. The number of elements of <span class="term">labels</span> MUST be equal to the
-number of fields of <span class="term">value</span>. Each <span class="user">colname</span> scalar array
+<p>An NTTable instance represents a table of data. The column data is given in scalar arrays in the structure field <span class="term">value</span>, and the column headings are given in field <span class="term">labels</span>. Each <span class="user">colname</span> scalar array
 field of <span class="term">value</span> contains the data for the column corresponding to the same indexed element of
 the <span class="term">labels</span> field.  Agents SHOULD use the elements of <span
 class="term">labels</span> as the column headings. <span class="nonnorm">There is no normative requirement that the
-field names of <span class="term">value</span> match the strings in <span class="term">labels</span>, though doing so is fine</span>. </p>
+field names of <span class="term">value</span> match the strings in <span class="term">labels</span></span>. </p>
 
 <p>Note that the above description is given in terms of a table and its columns,
 but there is nothing specifically columnar about how this data may be rendered. A
-user may choose to print the fields row wise. For instance, if there are many fields in <span class="term">value</span>,
-but each has only length 1 or 2. For instance, if you wanted to give all the scalar data related
-to one device, then you might use an NTTable rendered in such a way.
+user may choose to print the fields row wise if, for instance, if there are many fields in <span class="term">value</span>,
+but each has only length 1 or 2. For example, if one wanted to give all the scalar data related
+to one device, then one might use an NTTable rendered in such a way.
 </p>
 
 <h4>Validation</h4>

--- a/mainPage/alpha/normativeTypes/normativeTypes.html
+++ b/mainPage/alpha/normativeTypes/normativeTypes.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-      "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!--
 Auth:  Greg White, SLAC, Nov-2011.
 Vers:  12-Aug-2015, Greg White
@@ -40,16 +40,17 @@ Todo: Check order of fields.
        
 ============================================================= 
 -->
+
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-
 <head>
-
-  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+  <meta name="generator" content=
+  "HTML Tidy for Mac OS X (vers 31 October 2006 - Apple Inc. build 15.15), see www.w3.org" />
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
   <meta name="keywords" content="EPICS, EPICSv4" />
+
   <title>EPICS V4 Normative Types</title>
   <link rel="stylesheet" type="text/css" href="../../base.css" />
-  <link rel="stylesheet" type="text/css"   href="../../epicsv4.css" />
-
+  <link rel="stylesheet" type="text/css" href="../../epicsv4.css" />
   <!-- Styles comments:
    opt - Markup for standard optional fields of Normative Types
    nterm - Non-terminal symbol, in the grammar of Normative types
@@ -58,8 +59,9 @@ Todo: Check order of fields.
           i.e. user programmer supplies value.
    ed   - Comments included by the editor of this document.
   -->
+
   <style type="text/css">
-  /*<![CDATA[*/
+/*<![CDATA[*/
      .about { margin-left: 3em; margin-right: 3em; font-size: .83em}
      table { margin-left: auto; margin-right: auto }
      caption { font-size:smaller; font-style:italic; caption-side:bottom }
@@ -77,155 +79,177 @@ Todo: Check order of fields.
      span.ed { color: #AA0000 }
      p.ed.priv { display: inline; }
      span.ed.priv { display: inline; }
-  /*]]>*/</style>
+  /*]]>*/
+  </style><!-- Script that generates the Table of Contents -->
 
-  <!-- Script that generates the Table of Contents -->
-  <script type="text/javascript" src="../../script/tocgen.js"></script>
-
+  <script type="text/javascript" src="../../script/tocgen.js">
+</script>
 </head>
-		
-<body>
 
+<body>
   <div class="head">
     <h1>EPICS V4 Normative Types</h1>
 
-      <h2 class="nocount">EPICS V4 Normative Types, Editors Draft, 16-Mar-2015</h2>
-      <dl>
-	<dt id="latestversion">Latest version:</dt>
-	  <dd><a href="normativeTypes.html">normativeTypes.html</a></dd>
-	<dt id="thisversion">This version:</dt>
-	  <dd><a href="normativeTypes_20150316.html">normativeTypes_20150316.html</a></dd>
-	<dt>Previous version:</dt>
-	  <dd><a href="normativeTypes_20121018.html">normativeTypes_20121018.html</a></dd>
+    <h2 class="nocount">EPICS V4 Normative Types, Editors Draft,
+    16-Mar-2015</h2>
 
-	<dt>Editors:</dt>
-	  <dd>Greg White, SLAC</dd>
-	  <dd>Bob Dalesio, BNL</dd>
-	  <dd>Mark Rivers, APS (Invited Expert)</dd>
-	  <dd>Marty Kraimer, BNL</dd>
-	  <dd>David Hickin, Diamond</dd>
-      </dl>
-      <hr />
-      
-      <h2 class="nocount">Abstract</h2>
+    <dl>
+      <dt id="latestversion">Latest version:</dt>
 
-      <p>This document defines a set of standard high-level data types to
-      aid interoperability of peers at the application level of an EPICS V4
-      network.</p>
-      
-      <p>The abstract type definition and function of each such
-      standard type is described. For instance, one such type defined
-here, named "NTTable", defines a structure for expressing (in <a
- href="http://epics-pvdata.sourceforge.net/literature.html#pvDataJava"
- >pvData</a>) and communicating (using <a
- href="http://epics-pvdata.sourceforge.net/literature.html#pvAccessJava"
- >pvAccess</a>) a table of numeric or string data. </p>
+      <dd><a href="normativeTypes.html">normativeTypes.html</a></dd>
 
-    
-      <p>The data types described here are approximately equivalent to EPICS V3
-      Database Request types (commonly known as "DBR"
-      types), although Normative Types extend the concept to structured
-      data and operate at a higher level in a complex control system, or data exchange,
-      than DBR types. Also, Normative Types may be
-      used purely for data exchange though the dynamic data exchange interfaces
-      offered by EPICS V4's pvAccess and pvData modules, such as pvDatabase or pvAccess RPC
-      servers.</p>
+      <dt id="thisversion">This version:</dt>
 
-      <p>For more information about EPICS, please refer to the home page of the <a
-       href="http://www.aps.anl.gov/epics/">Experimental Physics and Industrial
-      Control System</a>, and to the homepage of <a
-       href="http://epics-pvdata.sourceforge.net" >EPICS Version 4</a>.</p>
+      <dd><a href=
+      "normativeTypes_20150316.html">normativeTypes_20150316.html</a></dd>
 
+      <dt>Previous version:</dt>
 
-      <h2 class="nocount">Status of this Document</h2>
-      <!-- Statement about why this version exists -->
-      
-      <p>This is the 16 Mar 2015 version of the Normative Types document, with the addition
-       of minor clarifications to the dscription of NTTable. The 16 Mar 2015 version
-       updates the definitions of time_t, control_t, display_t,
-       and alarmLimit_t and changes the order of optional fields in a
-       number of Normative Types.</p>
-       
-       <p>It replaces NTImage with NTNDArray, adds NTAttribute, NTMultiChannel,
-       NTUnion and NTScalarMultiChannel and removes
-       NTVariantArray and a number of types proposed in earlier drafts.</p>
+      <dd><a href=
+      "normativeTypes_20121018.html">normativeTypes_20121018.html</a></dd>
 
-      <p>This version contains a number of types which use pvData unions.</p>
+      <dt>Editors:</dt>
 
-      <p>It describes the new conventions for Normative Type IDs including 
-      versioning and namespaces. Type IDs for Normative Type structure
-      fields are given.</p>
+      <dd>Greg White, SLAC</dd>
 
-      <p>The linguistic conventions used in the document have been overhauled.</p> 
+      <dd>Bob Dalesio, BNL</dd>
 
+      <dd>Mark Rivers, APS (Invited Expert)</dd>
 
-      <p>See <a href="#appendix_a:_possible_future_additions_to_this_specification">
-      Appendix A</a> for items that may be added to future revisions of this
-      specification. </p>
+      <dd>Marty Kraimer, BNL</dd>
 
-      <p> This version is an Editors Draft towards the First Public Working
-      Draft. The First Public Working Draft will be intended for the EPICS community
-      to review and comment. Resulting comments will drive subsequent revisions of
-      the Normative Types specification and the EPICS V4 Working Group's reference
-      implementations of software that helps create, populate and exchange Normative
-      Type pvData.  </p>
+      <dd>David Hickin, Diamond</dd>
+    </dl>
+    <hr />
 
-      <p> Comments are welcome, though bear in mind this is a pre-public release
-      version. </p>
+    <h2 class="nocount">Abstract</h2>
 
-      <p>The terms MUST, MUST NOT, SHOULD, SHOULD NOT, REQUIRED, and MAY when
-      highlighted (through style sheets, and in uppercase in the source) are used in
-      accordance with RFC 2119 [RFC2119]. The term NOT REQUIRED (not defined in RFC
-      2119) indicates exemption. </p>
+    <p>This document defines a set of standard high-level data types to
+    aid interoperability of peers at the application level of an EPICS V4
+    network.</p>
 
-</div> <!-- head -->
+    <p>The abstract type definition and function of each such standard
+    type is described. For instance, one such type defined here, named
+    "NTTable", defines a structure for expressing (in <a href=
+    "http://epics-pvdata.sourceforge.net/literature.html#pvDataJava">pvData</a>)
+    and communicating (using <a href=
+    "http://epics-pvdata.sourceforge.net/literature.html#pvAccessJava">pvAccess</a>)
+    a table of numeric or string data.</p>
 
-<div id="toc" class="toc">
-  <h2 class="nocount">Table of Contents</h2>
-</div>
+    <p>The data types described here are approximately equivalent to EPICS
+    V3 Database Request types (commonly known as "DBR" types), although
+    Normative Types extend the concept to structured data and operate at a
+    higher level in a complex control system, or data exchange, than DBR
+    types. Also, Normative Types may be used purely for data exchange
+    though the dynamic data exchange interfaces offered by EPICS V4's
+    pvAccess and pvData modules, such as pvDatabase or pvAccess RPC
+    servers.</p>
 
-<div id="contents" class="contents">	  
-<hr />
-<h2 id="introduction">Introduction</h2>
+    <p>For more information about EPICS, please refer to the home page of
+    the <a href="http://www.aps.anl.gov/epics/">Experimental Physics and
+    Industrial Control System</a>, and to the homepage of <a href=
+    "http://epics-pvdata.sourceforge.net">EPICS Version 4</a>.</p>
 
-<p>The Normative Types described in this document are a set of software designs for
-high-level <a href="http://en.wikipedia.org/wiki/Data_type#Composite_types">
-composite data types</a> suitable for the application-level data exchange between
-EPICS V4 network endpoints. In particular, they are intended for use in online
-scientific data services. The intention is that where the endpoints in an EPICS V4
-network use only Normative Types, each peer in the network should be able to
-understand all the data transmitted to it, at least syntactically, and be able to
-take processing steps appropriate to that data.</p>
+    <h2 class="nocount">Status of this Document</h2>
+    <!-- Statement about why this version exists -->
 
-  <p>We call these types the <a
-    href="http://en.wikipedia.org/wiki/Normative#Standards_documents" >Normative</a>
-   Types, to emphasise their role as the prescriptions of abstract data structures,
-   whose role and intended semantics are described in this document, as opposed to
-    implemented software; and that conformance to these semantics is a necessary
-   condition for interoperability of using systems.</p>
+    <p>This revision of the Normative Types document is a minor
+    modification to the <a href="normativeTypes_20150316.html">16 Mar 2015
+    version</a>. This revision adds minor clarifications to the description
+    of NTTable.</p>
 
+    <p>The 16 Mar 2015 version updates the definitions of time_t,
+    control_t, display_t, and alarmLimit_t and changes the order of
+    optional fields in a number of Normative Types. It replaces NTImage
+    with NTNDArray, adds NTAttribute, NTMultiChannel, NTUnion and
+    NTScalarMultiChannel and removes NTVariantArray and a number of types
+    proposed in earlier drafts.</p>
 
-<p>The EPICS version 4 module pvData <a class="bib" href="#bib:pvdata">bib:pvdata</a>
-supplies a typing mechanism and object management API for efficiently defining,
-creating, accessing and updating memory resident structured data. EPICS V4 module
-pvAccess <a class="bib" href="#bib:pvaccess">bib:pvaccess</a> supports the efficient
-exchange of pvData defined data between EPICS V4 network peers. The EPICS V4 Normative
-Types specification defines some general purpose data types that build on pvData. These are
-designed to be generally applicable to the process control, and the software
-applications level, of scientific instruments. </p>
+    <p>This version contains a number of types which use pvData
+    unions.</p>
 
-<p>A simple example of a Normative Type described in this document is the one for
-  exchanging any single scalar value, such as one floating point number, one integer
-  or one string. That Normative Type is named "NTScalar". When a client receives a
-  pvData datum which identifies itself as being of type NTScalar, the client will
-  know to expect that the structure which carries the NTScalar will include the
-  scalar value in question (along with its type), and that value may be accompanied by up
-  to 5 additional fields: a description of the quality in question, a timestamp, an
-  indication of alarm severity, fields that help in how to display the value, and
-  data about its operating limits. See the example below.</p>
+    <p>It describes the new conventions for Normative Type IDs including
+    versioning and namespaces. Type IDs for Normative Type structure
+    fields are given.</p>
 
-<p>An example of a simple Normative Type is the NTScalar:</p>
-<pre><span class="nterm">NTScalar</span> := 
+    <p>The linguistic conventions used in the document have been
+    overhauled.</p>
+
+    <p>See <a href=
+    "#appendix_a:_possible_future_additions_to_this_specification">Appendix
+    A</a> for items that may be added to future revisions of this
+    specification.</p>
+
+    <p>This version is an Editors Draft towards the First Public Working
+    Draft. The First Public Working Draft will be intended for the EPICS
+    community to review and comment. Resulting comments will drive
+    subsequent revisions of the Normative Types specification and the
+    EPICS V4 Working Group's reference implementations of software that
+    helps create, populate and exchange Normative Type pvData.</p>
+
+    <p>Comments are welcome, though bear in mind this is a pre-public
+    release version.</p>
+
+    <p>The terms MUST, MUST NOT, SHOULD, SHOULD NOT, REQUIRED, and MAY
+    when highlighted (through style sheets, and in uppercase in the
+    source) are used in accordance with RFC 2119 [RFC2119]. The term NOT
+    REQUIRED (not defined in RFC 2119) indicates exemption.</p>
+  </div><!-- head -->
+
+  <div id="toc" class="toc">
+    <h2 class="nocount">Table of Contents</h2>
+  </div>
+
+  <div id="contents" class="contents">
+    <hr />
+
+    <h2 id="introduction">Introduction</h2>
+
+    <p>The Normative Types described in this document are a set of
+    software designs for high-level <a href=
+    "http://en.wikipedia.org/wiki/Data_type#Composite_types">composite
+    data types</a> suitable for the application-level data exchange
+    between EPICS V4 network endpoints. In particular, they are intended
+    for use in online scientific data services. The intention is that
+    where the endpoints in an EPICS V4 network use only Normative Types,
+    each peer in the network should be able to understand all the data
+    transmitted to it, at least syntactically, and be able to take
+    processing steps appropriate to that data.</p>
+
+    <p>We call these types the <a href=
+    "http://en.wikipedia.org/wiki/Normative#Standards_documents">Normative</a>
+    Types, to emphasize their role as the prescriptions of abstract data
+    structures, whose role and intended semantics are described in this
+    document, as opposed to implemented software; and that conformance to
+    these semantics is a necessary condition for interoperability of using
+    systems.</p>
+
+    <p>The EPICS version 4 module pvData <a class="bib" href=
+    "#bib:pvdata">bib:pvdata</a> supplies a typing mechanism and object
+    management API for efficiently defining, creating, accessing and
+    updating memory resident structured data. EPICS V4 module pvAccess
+    <a class="bib" href="#bib:pvaccess">bib:pvaccess</a> supports the
+    efficient exchange of pvData defined data between EPICS V4 network
+    peers. The EPICS V4 Normative Types specification defines some general
+    purpose data types that build on pvData. These are designed to be
+    generally applicable to the process control, and the software
+    applications level, of scientific instruments.</p>
+
+    <p>A simple example of a Normative Type described in this document is
+    the one for exchanging any single scalar value, such as one floating
+    point number, one integer or one string. That Normative Type is named
+    "NTScalar". When a client receives a pvData datum which identifies
+    itself as being of type NTScalar, the client will know to expect that
+    the structure which carries the NTScalar will include the scalar value
+    in question (along with its type), and that value may be accompanied
+    by up to 5 additional fields: a description of the quality in
+    question, a timestamp, an indication of alarm severity, fields that
+    help in how to display the value, and data about its operating limits.
+    See the example below.</p>
+
+    <p>An example of a simple Normative Type is the NTScalar:</p>
+    <pre>
+<span class="nterm">NTScalar</span> := 
 
 structure
     <span class="nterm">scalar_t</span>    value<span class="opt">
@@ -236,204 +260,237 @@ structure
     <span class="nterm">control_t</span>   control     :opt</span>
 </pre>
 
-<p> A more complex example: If a client receives a pvData datum which identifies
-itself as being of type NTTable, this document specifies that it should expect the
-datum to contain 0 or more arrays of potentially different types. The description of
-NTTable in this document will say that the client should interpret the arrays as the
-columns of a table, and should render such a datum appropriately as a table, with row
-elements being taken from the same numbered elements of each array.</p>
-
-<pre><span class="nterm">NTTable</span> := 
+    <p>A more complex example: If a client receives a pvData datum which
+    identifies itself as being of type NTTable, this document specifies
+    that it should expect the datum to contain 0 or more arrays of
+    potentially different types. The description of NTTable in this
+    document will say that the client should interpret the arrays as the
+    columns of a table, and should render such a datum appropriately as a
+    table, with row elements being taken from the same numbered elements
+    of each array.</p>
+    <pre>
+<span class="nterm">NTTable</span> := 
 
 structure 
   string[]    labels           // The field names of each field in value
   structure   value
-     {<span class="nterm">scalar_t[]</span> <span
-  class="user">colname</span>}0+  // 0 or more scalar array type
+     {<span class="nterm">scalar_t[]</span> <span class=
+"user">colname</span>}0+  // 0 or more scalar array type
                                // instances, the column values.<span class="opt">
   string      descriptor    : opt
   <span class="nterm">alarm_t</span>     alarm         : opt
   <span class="nterm">time_t</span>      timeStamp     : opt</span>
 </pre>
 
+    <h2>Description of Normative Types</h2>
 
+    <p>All the EPICS V4 Normative Types are defined as particular
+    structure instance definitions of a pvData <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure">
+    structure</a>. This is true even of the Normative Types describing
+    simple values like a single int, since all Normative Types optionally
+    include descriptor, alarm and timestamp. The fields of any given Ntype
+    datum instance can be ascertained at runtime using the <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#introspection_interfaces">
+    pvData Field introspection interface</a> <a class="bib" href=
+    "#bib:pvdata">bib:pvdata</a>.</p>
 
+    <p>See the <a href=
+    "#normative_type_instance_self-identification">Normative Type instance
+    self-identification</a> section below for more on how to examine a
+    given pvData instance to see which fields it includes. That section
+    also includes how to mark a pvData instance as a Normative Type, and
+    how to look for that mark.</p>
 
-<h2>Description of Normative Types</h2>
+    <p><span style="font-weight:bold;">Definition</span>: Normative
+    Type</p>
 
-<p>All the EPICS V4 Normative Types are defined as particular structure instance
-definitions of a pvData <a
- href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure"
- >structure</a>. This is true even of the Normative Types describing simple values
-like a single int, since all Normative Types optionally include descriptor,
-alarm and timestamp. The fields of any given
-Ntype datum instance can be ascertained at runtime using the <a
- href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#introspection_interfaces">
-pvData Field introspection interface</a> <a class="bib"
-href="#bib:pvdata">bib:pvdata</a>.</p>
+    <p>The Normative Types definitions in this document each have the
+    following general form:</p>
 
-<p>See the <a
-   href="#normative_type_instance_self-identification">Normative Type instance self-identification</a> section below for more on how to examine a given
-    pvData instance to see which fields it includes. That section also includes how
-    to mark a pvData instance as a Normative Type, and how to look for that
-    mark. </p>
+    <ol>
+      <li>They are defined as structures, composed of fields.</li>
 
-<p><span style="font-weight:bold;">Definition</span>: Normative Type</p>
-<p>The Normative Types definitions in this document each have the following general form:</p>
-<ol>
-  <li>They are defined as structures, composed of fields.</li>
-  <li>They usually have one primary field called "value", which encodes the most
-  important data of the type.</li>
-  <li>They are composed of required fields, and optional fields. The required
- fields come first, the optional fields follow.</li>
-  <li>The order of fields matters. Although the Normative Types pvData binding allows
-  for access though an <a href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#introspection_interfaces">introspection API</a>, senders must encode the fields in the order
-  described in this document.</li>
-</ol>
+      <li>They usually have one primary field called "value", which
+      encodes the most important data of the type.</li>
 
+      <li>They are composed of required fields, and optional fields. The
+      required fields come first, the optional fields follow.</li>
 
+      <li>The order of fields matters. Although the Normative Types pvData
+      binding allows for access though an <a href=
+      "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#introspection_interfaces">
+      introspection API</a>, senders must encode the fields in the order
+      described in this document.</li>
+    </ol>
 
-<h3>Linguistic conventions used in this document</h3>
+    <h3>Linguistic conventions used in this document</h3>
 
-<p>A Normative Type can be used both for sending data from client to service
-and from service to client. In this document we refer generally to an
-<em>agent</em>, being either a client or a server. If the agent is specifically at
-the user's end, we call it the <em>user agent</em>. <em>Client</em> and
-<em>server</em> refer to the directionality of the transaction, server being the
-agent that is doing the sending.</p>
+    <p>A Normative Type can be used both for sending data from client to
+    service and from service to client. In this document we refer
+    generally to an <em>agent</em>, being either a client or a server. If
+    the agent is specifically at the user's end, we call it the <em>user
+    agent</em>. <em>Client</em> and <em>server</em> refer to the
+    directionality of the transaction, server being the agent that is
+    doing the sending.</p>
 
-<p>The word "Ntype" is used as a short form of "Normative Type".</p>
+    <p>The word "Ntype" is used as a short form of "Normative Type".</p>
 
-<p>The Normative Type data descriptions are given with the syntactic
-conventions and grammar given below. The types are described in the <a
-href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#pvdata_meta_language">pvData
-"Meta" Language</a>. A BNF-like syntax is used in order to add clear
-distinctions between symbol types, particularly terminality, recurrence,
-which names a user is expected to add and which
-are predefined. This syntax is essentially Extended Backus-Naur Form (EBNF),
-with some slight modifications to preserve the order of terms and the rules for line ends and indentation in the pvData Meta language.</p>
+    <p>The Normative Type data descriptions are given with the syntactic
+    conventions and grammar given below. The types are described in the
+    <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#pvdata_meta_language">
+    pvData "Meta" Language</a>. A BNF-like syntax is used in order to add
+    clear distinctions between symbol types, particularly terminality,
+    recurrence, which names a user is expected to add and which are
+    predefined. This syntax is essentially Extended Backus-Naur Form
+    (EBNF), with some slight modifications to preserve the order of terms
+    and the rules for line ends and indentation in the pvData Meta
+    language.</p>
 
-<p>The syntactic conventions are as follows.</p>
+    <p>The syntactic conventions are as follows.</p>
 
-<p>First, the conventions for terminal and non-terminal types are:</p>
+    <p>First, the conventions for terminal and non-terminal types are:</p>
 
-<ul style="list-style: none;">
-<li>
-<span class="nterm">italics</span> - a non-terminal. These are used to stand for a choice 
-of pvData type, or named sequence of fields, or for a specific structure or union, and 
-hence non-terminal.
-</li>
+    <ul style="list-style: none;">
+      <li><span class="nterm">italics</span> - a non-terminal. These are
+      used to stand for a choice of pvData type, or named sequence of
+      fields, or for a specific structure or union, and hence
+      non-terminal.</li>
 
-<li>
-<span class="term">plaintext</span> - terminals. These will be either a pvData Meta Language keyword 
-or a label. The Meta language keywords consist of <span class="term">structure</span>, <span class="term">union</span>, <span class="term">any</span>, the scalar type keywords
-(<span class="term">boolean</span>,
-<span class="term">byte</span>,
-<span class="term">short</span>,
-<span class="term">int</span>,
-<span class="term">long</span>,
-<span class="term">double</span>,
-<span class="term">ubyte</span>,
-<span class="term">ushort</span>,
-<span class="term">uint</span>,
-<span class="term">ulong</span>,
-<span class="term">float</span>,
-<span class="term">double</span> and
-<span class="term">string</span>)
-and the corresponding arrays <span class="term">structure[]</span>, <span class="term">union[]</span>,
-<span class="term">any[]</span>, and scalar arrays (e.g. <span class="term">int[]</span>,
-<span class="term">double[]</span>).
-</li>
+      <li><span class="term">plaintext</span> - terminals. These will be
+      either a pvData Meta Language keyword or a label. The Meta language
+      keywords consist of <span class="term">structure</span>,
+      <span class="term">union</span>, <span class="term">any</span>, the
+      scalar type keywords (<span class="term">boolean</span>,
+      <span class="term">byte</span>, <span class="term">short</span>,
+      <span class="term">int</span>, <span class="term">long</span>,
+      <span class="term">double</span>, <span class="term">ubyte</span>,
+      <span class="term">ushort</span>, <span class="term">uint</span>,
+      <span class="term">ulong</span>, <span class="term">float</span>,
+      <span class="term">double</span> and <span class=
+      "term">string</span>) and the corresponding arrays <span class=
+      "term">structure[]</span>, <span class="term">union[]</span>,
+      <span class="term">any[]</span>, and scalar arrays (e.g.
+      <span class="term">int[]</span>, <span class=
+      "term">double[]</span>).</li>
 
-<li>
-<span class="user">name</span> - A user-provided label name.A programmer using the Normative Type will choose what goes in the &lt;&gt;. 
-</li>
-</ul>
+      <li><span class="user">name</span> - A user-provided label name.A
+      programmer using the Normative Type will choose what goes in the
+      &lt;&gt;.</li>
+    </ul>
 
-<p>So, for example, <a href="#scalar_t"><span class="nterm">scalar_t</span></a> is non-terminal
- as it stands for a choice of pvData type and <a href="#time_t"><span class="nterm">time_t</span></a> is non-terminal because it stands for a particular structure.
+    <p>So, for example, <a href="#scalar_t"><span class=
+    "nterm">scalar_t</span></a> is non-terminal as it stands for a choice
+    of pvData type and <a href="#time_t"><span class=
+    "nterm">time_t</span></a> is non-terminal because it stands for a
+    particular structure. On the other hand, in the definition of
+    <span class="nterm">time_t</span>, <span class="term">long</span> and
+    <span class="term">secondsPastEpoch</span> are a keyword and a label
+    respectively, and so are terminal, and the columns of <a href=
+    "#nttable"><span class="nterm">NTTable</span></a>, <span class=
+    "user">colname</span>, are user-provided labels.</p>
 
-On the other hand, in the definition of <span class="nterm">time_t</span>, <span class="term">long</span>
-and <span class="term">secondsPastEpoch</span> are a keyword and a label respectively, and so are terminal,
-and the columns of <a href="#nttable"><span class="nterm">NTTable</span></a>, <span
-  class="user">colname</span>, are user-provided labels.</p>
+    <p>In this section &lt;&gt; will also be used for describing patterns
+    of definitions or meta rules such as production rules of the grammar
+    to indicate a choice of terminal or non-terminal terms in the pattern
+    or rule.</p>
 
-<p>In this section &lt;&gt; will also be used for describing patterns of definitions or
- meta rules such as production rules of the grammar to indicate a choice of terminal or
- non-terminal terms in the pattern or rule.</p>
+    <p>The EBNF-like syntax for definitions is used. A description
+    consists of 3 terms - a left-hand side (LHS), a right-hand side (RHS),
+    and the symbol ":=" separating them, which is to be interpreted as
+    "LHS is defined as RHS". The LHS will be the non-terminal being
+    defined. The RHS will be a sequence of terminal or non-terminal
+    terms.</p>
 
-<p>The EBNF-like syntax for definitions is used. A description consists of 3
-terms - a left-hand side (LHS), a right-hand side (RHS), and the symbol ":="
-separating them, which is to be interpreted as "LHS is defined as RHS". The LHS
-will be the non-terminal being defined. The RHS will be a sequence of terminal or non-terminal terms.</p>
+    <p>Note that in the definitions below line-ends (EOLs) are not
+    explicitly specified. They are implied except when multiple lines are
+    used to specify alternatives separated by |, where only the final EOL
+    is implied.</p>
 
-<p>Note that in the definitions below line-ends (EOLs) are not explicitly specified.
-They are implied except when multiple lines are used to specify alternatives separated
-by |, where only the final EOL is implied.</p>
+    <p>The following EBNF symbols are also used:</p>
 
-<p>The following EBNF symbols are also used:</p>
+    <ul style="list-style: none;">
+      <li>| - used to separate alternative items; one item is chosen from
+      this list of alternatives.</li>
 
-<ul style="list-style: none;">
-<li>| - used to separate alternative items; one item is chosen from this list of
-alternatives.
-</li>
-<li>
-[] - optional items are enclosed between square brackets [ and ]; the item can either be included or discarded. Note, optional fields of structures are marked as such by the use of <span class="term">:opt</span> instead of square brackets.
-</li><li>
-&#123; &#125; - a sequence of occurrences of the item or items in the braces. The
-number of occurrences follows. 0+ means 0 or more. 1+ means 1 or more.
-</li>
-</ul>
+      <li>[] - optional items are enclosed between square brackets [ and
+      ]; the item can either be included or discarded. Note, optional
+      fields of structures are marked as such by the use of <span class=
+      "term">:opt</span> instead of square brackets.</li>
 
+      <li>{ } - a sequence of occurrences of the item or items in the
+      braces. The number of occurrences follows. 0+ means 0 or more. 1+
+      means 1 or more.</li>
+    </ul>
 
+    <p>The following production rules are employed:</p>
 
-<p>The following production rules are employed:</p> 
+    <ol>
+      <li>Replace a non-terminal by its definition, except where the
+      non-terminal defines a structure or union and is followed by a field
+      name. (The modified rule for non-terminal structures and unions is
+      described below.)</li>
 
-<ol>
-<li>Replace a non-terminal by its definition, except where the non-terminal defines a structure or union and is followed by a field name. (The modified rule for non-terminal structures and unions is described below.)</li>
-<li>Choose an alternative for items separated by |.</li>
-<li>Choose a user supplied label for items between angle brackets (&lt; and &gt;).</li>
-<li>Include or discard items between square brackets ([ and ]). Note this excludes a pair of square brackets ([]) used to signify an array.</li>
-<li>Include or discard fields marked <span class="term">:opt</span>.</li>
-<li>For items between braces ({ and }) replace with an appropriate number of
-occurences of the item. For a sequence of pvData fields a line-end (EOL) is implied after each one.</li>
-</ol>
+      <li>Choose an alternative for items separated by |.</li>
 
-<p>In the case of structure and union fields, to preserve the order of terms in
- the pvData Meta language, as well as obtaining appropriate indentation, 
- the usual EBNF rule of replacing a non-terminal by its definition requires the following modification:</p>
+      <li>Choose a user supplied label for items between angle brackets
+      (&lt; and &gt;).</li>
 
-<p>Suppose a non-terminal term has a definition of the form</p>
+      <li>Include or discard items between square brackets ([ and ]). Note
+      this excludes a pair of square brackets ([]) used to signify an
+      array.</li>
 
-<pre>
+      <li>Include or discard fields marked <span class=
+      "term">:opt</span>.</li>
+
+      <li>For items between braces ({ and }) replace with an appropriate
+      number of occurrences of the item. For a sequence of pvData fields a
+      line-end (EOL) is implied after each one.</li>
+    </ol>
+
+    <p>In the case of structure and union fields, to preserve the order of
+    terms in the pvData Meta language, as well as obtaining appropriate
+    indentation, the usual EBNF rule of replacing a non-terminal by its
+    definition requires the following modification:</p>
+
+    <p>Suppose a non-terminal term has a definition of the form</p>
+    <pre>
 &lt;<span class="nterm">non-terminal</span>&gt;:=
 
 structure
     <span class="user">fieldList</span>
 </pre>
-<p>where:</p>
-<dl>
-  <dt>&lt;<span class="nterm">non-terminal</span>&gt;</dt>
-    <dd>The non-terminal term being defined.</dd>
-  <dt><span class="user">fieldName</span></dt>
-    <dd>A choice of terminal or non-terminal terms describing a a list or 0 or more pvData fields.</dd>
-</dl>
-Then for a label (a field name), <span class="user">fieldName</span>, the terms
-<pre>
-&lt;<span class="nterm">non-terminal</span>&gt; <span class="user">fieldName</span>
-</pre>
-are replaced by 
-<pre>
+
+    <p>where:</p>
+
+    <dl>
+      <dt>&lt;<span class="nterm">non-terminal</span>&gt;</dt>
+
+      <dd>The non-terminal term being defined.</dd>
+
+      <dt><span class="user">fieldName</span></dt>
+
+      <dd>A choice of terminal or non-terminal terms describing a a list
+      or 0 or more pvData fields.</dd>
+    </dl>Then for a label (a field name), <span class=
+    "user">fieldName</span>, the terms
+    <pre>
+&lt;<span class="nterm">non-terminal</span>&gt; <span class=
+"user">fieldName</span>
+</pre>are replaced by
+    <pre>
 structure <span class="user">fieldName</span>
     <span class="user">fieldList</span>
 </pre>
-<p>The result of the any substitution is suitably indented to preserve the logic of the pvData meta language.</p>
 
+    <p>The result of the any substitution is suitably indented to preserve
+    the logic of the pvData meta language.</p>
 
-<p>Thus the structure derived from the definition of
-<a href="#ntenum"><span class="nterm">NTEnum</span></a>
-below, with all optional fields present,  is</p>
-<pre>
+    <p>Thus the structure derived from the definition of <a href=
+    "#ntenum"><span class="nterm">NTEnum</span></a> below, with all
+    optional fields present, is</p>
+    <pre>
 structure
     structure  value
         int      index
@@ -447,109 +504,147 @@ structure
         int      severity
         int      status
         string   message
-</pre> 
+</pre>
 
-<p>The same rule also applies with <span class="term">union</span> in place of <span class="term">structure</span>.</p>
+    <p>The same rule also applies with <span class="term">union</span> in
+    place of <span class="term">structure</span>.</p>
 
-<p>The grammar for a Normative Type definition follows the pattern
-below. That is, a Normative Type is defined as a structure composed of fields. A
-field may be optional, and may be described along with a comment:</p>
-
-<pre>&lt;<span class="nterm">NormativeType</span>&gt;:=
+    <p>The grammar for a Normative Type definition follows the pattern
+    below. That is, a Normative Type is defined as a structure composed of
+    fields. A field may be optional, and may be described along with a
+    comment:</p>
+    <pre>
+&lt;<span class="nterm">NormativeType</span>&gt;:=
 
 structure 
-   { <span class="user">pvDataField</span> [:opt] [// <span class="user">commentText]</span>] }1+
+   { <span class="user">pvDataField</span> [:opt] [// <span class=
+"user">commentText]</span>] }1+
 </pre>
-<p>where:</p>
-<dl>
-  <dt>&lt;<span class="nterm">NormativeType</span>&gt;</dt>
-    <dd>The name of the Normative Type being defined.</dd>
-  <dt><span class="user">pvDataField</span></dt>
-    <dd>A choice of terms defining a pvData field</dd>
-   <dt>:opt</dt>
-    <dd>Indicates that the preceding field is optional in the Normative Type.</dd>
+
+    <p>where:</p>
+
+    <dl>
+      <dt>&lt;<span class="nterm">NormativeType</span>&gt;</dt>
+
+      <dd>The name of the Normative Type being defined.</dd>
+
+      <dt><span class="user">pvDataField</span></dt>
+
+      <dd>A choice of terms defining a pvData field</dd>
+
+      <dt>:opt</dt>
+
+      <dd>Indicates that the preceding field is optional in the Normative
+      Type.</dd>
+
       <dt>// <span class="user">commentText</span></dt>
+
       <dd>A field production element may be followed by a comment.</dd>
-</dl>
+    </dl>
 
-<p>In most cases a Normative Type definition will be of the form</p>
-
-<pre>&lt;<span class="nterm">NTname</span>&gt;:=
+    <p>In most cases a Normative Type definition will be of the form</p>
+    <pre>
+&lt;<span class="nterm">NTname</span>&gt;:=
 
 structure 
-   { <span class="user">ntfieldChoice</span> <span class="user">fieldName</span> [:opt] [// <span class="user">commentText</span>] }1+
+   { <span class="user">ntfieldChoice</span> <span class=
+"user">fieldName</span> [:opt] [// <span class=
+"user">commentText</span>] }1+
 </pre>
-<p>where:</p>
-<dl>
-  <dt><span class="user">ntfieldChoice</span></dt>
-    <dd>Terminal or non-terminal terms, possibly sepated by |, from the valid
-  <a href="#normative_type_fields">Normative Type Fields</a> as defined below.</dd>
-  <dt><span class="user">fieldName</span></dt>
-    <dd>The identifier of the field. Usually a terminal label.</dd>
-</dl>
 
-For example, a definition meeting this pattern would be
+    <p>where:</p>
 
-<pre><span class="nterm">NTExample</span> := 
+    <dl>
+      <dt><span class="user">ntfieldChoice</span></dt>
+
+      <dd>Terminal or non-terminal terms, possibly separated by |, from the
+      valid <a href="#normative_type_fields">Normative Type Fields</a> as
+      defined below.</dd>
+
+      <dt><span class="user">fieldName</span></dt>
+
+      <dd>The identifier of the field. Usually a terminal label.</dd>
+    </dl>For example, a definition meeting this pattern would be
+    <pre>
+<span class="nterm">NTExample</span> := 
 
 structure
-    <span class="nterm">enum_t</span> | <span class="nterm">scalar_t</span>   value<span class="opt">
+    <span class="nterm">enum_t</span> | <span class=
+"nterm">scalar_t</span>   value<span class="opt">
     int                 N                  // this field has a comment
     string              descriptor  :opt
     <span class="nterm">alarm_t</span>             alarm       :opt
     <span class="nterm">time_t</span>              timeStamp   :opt</span>
 </pre>
 
-<h2>Normative Type Fields</h2>
+    <h2>Normative Type Fields</h2>
 
-<p>This section defines the fields that may appear in a Normative Type's
-definition.</p>
+    <p>This section defines the fields that may appear in a Normative
+    Type's definition.</p>
 
-<p>Each field of a Normative Type will typically be
-one of the following: </p>
-
-<pre>
+    <p>Each field of a Normative Type will typically be one of the
+    following:</p>
+    <pre>
 <span class="nterm">ntfield</span> := 
 
-  <span class="nterm">scalar_t</span>        // a simple numerical, boolean, or string value
+  <span class=
+"nterm">scalar_t</span>        // a simple numerical, boolean, or string value
 | <span class="nterm">scalar_t[]</span>      // an array of simple values
 | <span class="nterm">enum_t</span>          // an enumeration
 | <span class="nterm">enum_t[]</span>        // an array of enumerations 
-| <span class="nterm">time_t</span>          // a point in time, used for timestamps
+| <span class=
+"nterm">time_t</span>          // a point in time, used for timestamps
 | <span class="nterm">time_t[]</span>        // an array of points in time
-| <span class="nterm">alarm_t</span>         // a summary diagnostic of a control system event
-| <span class="nterm">alarm_t[]</span>       // an array of summary diagnostics
-| <span class="nterm">alarmLimit_t</span>    // value thresholds for a control system diagnostic report
-| <span class="nterm">alarmLimit_t[]</span>  // an array of threshold values
+| <span class=
+"nterm">alarm_t</span>         // a summary diagnostic of a control system event
+| <span class=
+"nterm">alarm_t[]</span>       // an array of summary diagnostics
+| <span class=
+"nterm">alarmLimit_t</span>    // value thresholds for a control system diagnostic report
+| <span class=
+"nterm">alarmLimit_t[]</span>  // an array of threshold values
 | <span class="nterm">display_t</span>       // metadata of displayed data
-| <span class="nterm">display_t[]</span>     // an array of display metadata
-| <span class="nterm">control_t</span>       // control setpoint range boundaries 
-| <span class="nterm">control_t[]</span>     // an array of control setpoint range boundaries
+| <span class=
+"nterm">display_t[]</span>     // an array of display metadata
+| <span class=
+"nterm">control_t</span>       // control setpoint range boundaries 
+| <span class=
+"nterm">control_t[]</span>     // an array of control setpoint range boundaries
 | <span class="term">any</span>             // a variant union type
-| <span class="term">any[]</span>           // an array of variant unions fields
-| <span class="nterm">ntunion_t</span>       // a regular union storing ntfields only
-| <span class="nterm">ntunion_t[]</span>     // a regular union array storing ntfields only
+| <span class=
+"term">any[]</span>           // an array of variant unions fields
+| <span class=
+"nterm">ntunion_t</span>       // a regular union storing ntfields only
+| <span class=
+"nterm">ntunion_t[]</span>     // a regular union array storing ntfields only
 | <span class="nterm">union_t</span>         // any regular union
 | <span class="nterm">union_t[]</span>       // any regular union array
-| <span class="nterm">anyunion_t</span>      // any variant or regular union
-| <span class="nterm">anyunion_t[]</span>    // any variant or regular union array
+| <span class=
+"nterm">anyunion_t</span>      // any variant or regular union
+| <span class=
+"nterm">anyunion_t[]</span>    // any variant or regular union array
 </pre>
 
-<p>although some examples may have fields of other types.</p>
+    <p>although some examples may have fields of other types.</p>
 
-<h3>Simple Normative Type fields - scalar and scalar array types</h3>
+    <h3>Simple Normative Type fields - scalar and scalar array types</h3>
 
-<p>Note that of all the Normative Type fields only <span class="nterm">scalar_t</span> and <span class="nterm">scalar_t[]</span> are of simple type,
-that is, having a single scalar or scalar array value of a fixed type. All the others are represented by a
-complex type, i.e. a structure or union or arrays of structures or unions (see <a href="#structured_normative_type_fields">Structured Normative
-Type fields</a> and <a href="#union_normative_type_fields">Union Normative Type fields</a>
- below). </p>
+    <p>Note that of all the Normative Type fields only <span class=
+    "nterm">scalar_t</span> and <span class="nterm">scalar_t[]</span> are
+    of simple type, that is, having a single scalar or scalar array value
+    of a fixed type. All the others are represented by a complex type,
+    i.e. a structure or union or arrays of structures or unions (see
+    <a href="#structured_normative_type_fields">Structured Normative Type
+    fields</a> and <a href="#union_normative_type_fields">Union Normative
+    Type fields</a> below).</p>
 
-<h4 id ="scalar_t">scalar_t</h4>
+    <h4 id="scalar_t">scalar_t</h4>
 
-<p>The field is a scalar value. Scalar fields would be implemented with pvData field
-  Type <a href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_scalar" >"scalar"</a>:</p>
-<pre>
+    <p>The field is a scalar value. Scalar fields would be implemented
+    with pvData field Type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_scalar">
+    "scalar"</a>:</p>
+    <pre>
 <span class="nterm">scalar_t</span> :=
 
    boolean  // true or false 
@@ -566,14 +661,13 @@ Type fields</a> and <a href="#union_normative_type_fields">Union Normative Type 
 |  string   // UTF-8 *
 </pre>
 
-<h4>scalar_t[]</h4>
+    <h4>scalar_t[]</h4>
 
-<p>The field is an array of scalars. Scalar array fields would be implemented with
-  a pvData field of type <a
-   href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_scalar_array"
-   >"scalarArray"</a>:</p>
-
-<pre>
+    <p>The field is an array of scalars. Scalar array fields would be
+    implemented with a pvData field of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_scalar_array">
+    "scalarArray"</a>:</p>
+    <pre>
 <span class="nterm">scalar_t[]</span> :=
 
    boolean[]  // array of true or false
@@ -587,30 +681,30 @@ Type fields</a> and <a href="#union_normative_type_fields">Union Normative Type 
 |  ulong[]    // array of 64 bit unsigned integer
 |  float[]    // array of single precision IEEE 754
 |  double[]   // array of double precision IEEE 754
-|  string[]   // array of UTF-8 *</pre>
+|  string[]   // array of UTF-8 *
+</pre>
 
+    <h3>Structured Normative Type fields</h3>
 
+    <p>This subsection defines those fields of a Normative Type structure
+    definition that are themselves structures or arrays of structures.</p>
 
-<h3>Structured Normative Type fields</h3>
+    <p>The structured Normative Type fields would be implemented with type
+    pvData field type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure">
+    "structure"</a> or <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array">
+    "structureArray"</a>.</p>
 
-<p>This subsection defines those fields of a Normative Type structure definition
- that are themselves structures or arrays of structures.</p>
+    <h4>enum_t</h4>
 
-<p>The structured Normative Type fields would be implemented with type pvData field type <a
-href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure"
->"structure"</a> or <a
-href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array"
->"structureArray"</a>.</p>
-
-<h4>enum_t</h4>
-
-<p>An <span class="nterm">enum_t</span> describes an enumeration. The field is a
-  structure describing a value drawn from a given set of valid values also given. It
-  is implemented as a pvData Field of type <a
-   href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure"
-   >"structure"</a> of type ID "enum_t" with the following form:</p>
-
-<pre>
+    <p>An <span class="nterm">enum_t</span> describes an enumeration. The
+    field is a structure describing a value drawn from a given set of
+    valid values also given. It is implemented as a pvData Field of type
+    <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure">
+    "structure"</a> of type ID "enum_t" with the following form:</p>
+    <pre>
 <span class="nterm">enum_t</span> :=
 
 structure
@@ -618,83 +712,98 @@ structure
     string[] choices
 </pre>
 
-<p>where:</p>
-<dl>
-  <dt>index</dt>
-    <dd>The index of the current value of the enumeration in the array
+    <p>where:</p>
+
+    <dl>
+      <dt>index</dt>
+
+      <dd>The index of the current value of the enumeration in the array
       choices below.</dd>
-  <dt>choices</dt>
-    <dd>An array of strings specifying the set of labels for the valid values
-      of the enumeration.</dd>
-</dl>
 
-<h4>enum_t[]</h4>
+      <dt>choices</dt>
 
-<p>An <span class="nterm">enum_t[]</span> describes an array of enumerations. The
-  field is an array of structures each describing a value drawn from a given set of
-  valid values also given in each. It is implemented as a pvData field of type <a
-  href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array"
-  >"structureArray"</a>, each element of which is a structure of the form <span
-  class="nterm">enum_t</span> above.</p>
+      <dd>An array of strings specifying the set of labels for the valid
+      values of the enumeration.</dd>
+    </dl>
 
+    <h4>enum_t[]</h4>
 
-<h4 id = "time_t" >time_t</h4>
+    <p>An <span class="nterm">enum_t[]</span> describes an array of
+    enumerations. The field is an array of structures each describing a
+    value drawn from a given set of valid values also given in each. It is
+    implemented as a pvData field of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array">
+    "structureArray"</a>, each element of which is a structure of the form
+    <span class="nterm">enum_t</span> above.</p>
 
-<p>A <span class="nterm">time_t</span> describes a defined point in time. The field is a structure
-describing a time relative to midnight on January 1st, 1970 UTC. It is implemented as a pvData field of type
-<a href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure" >"structure"</a>
-of type ID "time_t" and with the following form: </p>
+    <h4 id="time_t">time_t</h4>
 
-<pre>
+    <p>A <span class="nterm">time_t</span> describes a defined point in
+    time. The field is a structure describing a time relative to midnight
+    on January 1st, 1970 UTC. It is implemented as a pvData field of type
+    <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure">
+    "structure"</a> of type ID "time_t" and with the following form:</p>
+    <pre>
 <span class="nterm">time_t</span> :=
 
 structure
     long secondsPastEpoch
     int  nanoseconds
-    int  userTag</pre>
+    int  userTag
+</pre>
 
-<p>where:</p>
-<dl>
-  <dt>secondsPastEpoch</dt>
-    <dd>Seconds since Jan 1, 1970 00:00:00 UTC.</dd>
-  <dt>nanoseconds</dt>
-    <dd>Nanoseconds relative to the <span class="term">secondsPastEpoch</span> field.</dd>
-  <dt>userTag</dt>
-    <dd>An integer value whose interpretation is deliberately undefined and therefore MAY be
-      used by EPICS V4 agents in a user defined way.</dd>
-</dl>
+    <p>where:</p>
 
-<p>Interpretation: The point in time being identified by a <span
-class="nterm">time_t</span>, is given by Jan 1, 1970 00:00:00 UTC plus some
-nanoseconds given by its <span class="term">secondsPastEpoch</span>
-times 10<sup>9</sup> plus its <span class="term">nanoseconds</span>.</p>
+    <dl>
+      <dt>secondsPastEpoch</dt>
 
+      <dd>Seconds since Jan 1, 1970 00:00:00 UTC.</dd>
 
-<h4>time_t[]</h4>
+      <dt>nanoseconds</dt>
 
-<p>A <span class="nterm">time_t[]</span> describes an array of points in time. The
- field is an array of structures each describing a time relative to January 1st, 1970
- UTC. It is implemented as a pvData field of type <a
-  href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array"
-  >"structureArray"</a>, each element of which is a structure of the form <span
- class="nterm">time_t</span> above.</p>
+      <dd>Nanoseconds relative to the <span class=
+      "term">secondsPastEpoch</span> field.</dd>
 
+      <dt>userTag</dt>
 
-<h4>alarm_t</h4>
+      <dd>An integer value whose interpretation is deliberately undefined
+      and therefore MAY be used by EPICS V4 agents in a user defined
+      way.</dd>
+    </dl>
 
-<p>An <span class="nterm">alarm_t</span> describes a diagnostic of the value of a
-control system process variable. It indicates essentially whether the associated value
-is good or bad, and whether agent systems should alert people to the status of the process.</p>
+    <p>Interpretation: The point in time being identified by a
+    <span class="nterm">time_t</span>, is given by Jan 1, 1970 00:00:00
+    UTC plus some nanoseconds given by its <span class=
+    "term">secondsPastEpoch</span> times 10<sup>9</sup> plus its
+    <span class="term">nanoseconds</span>.</p>
 
-<p> Processes in EPICS V3 and V4 IOCs include extensive support for evaluating
-alarm conditions. The definition of the fields in an <span class="term">alarm</span>
-are given in <a class="bib" href="#bib:epicsrecref">bib:epicsrecref</a>.  The field is a
-structure describing an alarm. It is implemented as a pvData field of type
-<a
- href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure"
- >"structure"</a> of type ID "alarm_t" with the following form: </p>
+    <h4>time_t[]</h4>
 
-<pre>
+    <p>A <span class="nterm">time_t[]</span> describes an array of points
+    in time. The field is an array of structures each describing a time
+    relative to January 1st, 1970 UTC. It is implemented as a pvData field
+    of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array">
+    "structureArray"</a>, each element of which is a structure of the form
+    <span class="nterm">time_t</span> above.</p>
+
+    <h4>alarm_t</h4>
+
+    <p>An <span class="nterm">alarm_t</span> describes a diagnostic of the
+    value of a control system process variable. It indicates essentially
+    whether the associated value is good or bad, and whether agent systems
+    should alert people to the status of the process.</p>
+
+    <p>Processes in EPICS V3 and V4 IOCs include extensive support for
+    evaluating alarm conditions. The definition of the fields in an
+    <span class="term">alarm</span> are given in <a class="bib" href=
+    "#bib:epicsrecref">bib:epicsrecref</a>. The field is a structure
+    describing an alarm. It is implemented as a pvData field of type
+    <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure">
+    "structure"</a> of type ID "alarm_t" with the following form:</p>
+    <pre>
 <span class="nterm">alarm_t</span> :=
 
 structure
@@ -703,53 +812,57 @@ structure
     string message
 </pre>
 
-<p>where:</p>
-<dl>
-  <dt>severity</dt>
-      <dd>severity is defined as an int (not an <span class="nterm">enum_t</span>), but
-      MUST be functionally interpreted as the enumeration
-	{noAlarm, minorAlarm, majorAlarm, invalidAlarm, undefinedAlarm } indexed from
-	noAlarm=0  <a
-class="bib" href="#bib:epicsrecref">bib:epicsrecref</a>.</dd>
-  <dt>status</dt>
-      <dd>status is defined as an int (not an <span class="nterm">enum_t</span>), but
-      MUST be functionally interpreted as the enumeration {noStatus, deviceStatus,
-	driverStatus, recordStatus,
-    dbStatus, confStatus, undefinedStatus, clientStatus } indexed from noStatus=0
-	 <a
-class="bib" href="#bib:epicsrecref">bib:epicsrecref</a>.</dd>
-  <dt>message</dt>
-    <dd>A message string.</dd>
-</dl>
+    <p>where:</p>
 
-<p>Interpretation MUST be as with V3 IOC record processing, as described in the EPICS
-Reference Manual <a
-class="bib" href="#bib:epicsrecref">bib:epicsrecref</a>.</p>
+    <dl>
+      <dt>severity</dt>
 
-<h4>alarm_t[]</h4>
+      <dd>severity is defined as an int (not an <span class=
+      "nterm">enum_t</span>), but MUST be functionally interpreted as the
+      enumeration {noAlarm, minorAlarm, majorAlarm, invalidAlarm,
+      undefinedAlarm } indexed from noAlarm=0 <a class="bib" href=
+      "#bib:epicsrecref">bib:epicsrecref</a>.</dd>
 
-<p>An <span class="nterm">alarm_t[]</span> is an array of alarm conditions. The field
-is an array of structures each describing an alarm condition. It is implemented as a pvData field of type <a
-  href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array"
-  >"structureArray"</a>, each element of which is a structure of the form <span
-class="nterm">alarm_t</span> above.</p>
+      <dt>status</dt>
 
+      <dd>status is defined as an int (not an <span class=
+      "nterm">enum_t</span>), but MUST be functionally interpreted as the
+      enumeration {noStatus, deviceStatus, driverStatus, recordStatus,
+      dbStatus, confStatus, undefinedStatus, clientStatus } indexed from
+      noStatus=0 <a class="bib" href=
+      "#bib:epicsrecref">bib:epicsrecref</a>.</dd>
 
-<h4>alarmLimit_t</h4>
+      <dt>message</dt>
 
+      <dd>A message string.</dd>
+    </dl>
 
-<p>An <span class="nterm">alarmLimit_t</span> is a structure that gives the numeric
-  intervals to be used for the high and low limit ranges of an associated value field.
-  The specific value to which the alarmLimit refers, is not
-  specified in the alarmLimit structure. It is usually a value field of type double that appears in
-  the same structure as the alarmLimit.
-<span
-class="nterm">alarmLimit_t</span> is implemented as a pvData field of type <a
- href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure"
- >"structure"</a> of type ID "alarmLimit_t" with the following form: </p>
+    <p>Interpretation MUST be as with V3 IOC record processing, as
+    described in the EPICS Reference Manual <a class="bib" href=
+    "#bib:epicsrecref">bib:epicsrecref</a>.</p>
 
+    <h4>alarm_t[]</h4>
 
-<pre><span class="nterm">alarmLimit_t</span> :=
+    <p>An <span class="nterm">alarm_t[]</span> is an array of alarm
+    conditions. The field is an array of structures each describing an
+    alarm condition. It is implemented as a pvData field of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array">
+    "structureArray"</a>, each element of which is a structure of the form
+    <span class="nterm">alarm_t</span> above.</p>
+
+    <h4>alarmLimit_t</h4>
+
+    <p>An <span class="nterm">alarmLimit_t</span> is a structure that
+    gives the numeric intervals to be used for the high and low limit
+    ranges of an associated value field. The specific value to which the
+    alarmLimit refers, is not specified in the alarmLimit structure. It is
+    usually a value field of type double that appears in the same
+    structure as the alarmLimit. <span class="nterm">alarmLimit_t</span>
+    is implemented as a pvData field of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure">
+    "structure"</a> of type ID "alarmLimit_t" with the following form:</p>
+    <pre>
+<span class="nterm">alarmLimit_t</span> :=
 
 structure
     boolean active
@@ -761,110 +874,139 @@ structure
     int lowWarningSeverity
     int highWarningSeverity
     int highAlarmSeverity
-    double hysteresis</pre>
+    double hysteresis
+</pre>
 
-<p>where:</p>
-<dl>
-  <dt>active</dt>
-    <dd>Is alarming active?
-      If no then alarms are not raised.
-       If yes then the associated value is checked for alarm conditions.
-    </dd>
-  <dt>lowAlarmLimit</dt>
-    <dd>If the value is &lt;= lowAlarmLimit then the severity is lowAlarmSeverity.</dd>
-  <dt>lowWarningLimit</dt>
-    <dd>If the value is &gt; lowAlarmLimit and &lt;= lowWarningLimit then the severity is lowWarningSeverity.</dd>
-  <dt>highWarningLimit</dt>
-    <dd>If the value is &gt;= highWarningLimit and &lt; highAlarmLimit then the severity is highWarningLimit.</dd>
-  <dt>highAlarmLimit</dt>
-    <dd>If the value is &gt;= highAlarmLimit then the severity is highAlarmSeverity.</dd>
-  <dt>lowAlarmSeverity</dt>
-     <dd>Severity for value that satisfies lowAlarmLimit.</dd>
-  <dt>lowWarningSeverity</dt>
-     <dd>Severity for value that satisfies lowWarningLimit.</dd>
-  <dt>highWarningSeverity</dt>
-     <dd>Severity for value that satisfies highWarningLimit.</dd>
-  <dt>highAlarmSeverity</dt>
-     <dd>Severity for value that satisfies highAlarmLimit.</dd>
-  <dt>hysteresis</dt>
-     <dd>When a value enters an alarm limit this is how much it must change before is it put into a lower severity state.
-      This prevents alarm chatter.
-     </dd>
-</dl>
+    <p>where:</p>
 
-<p>Code that checks for alarms should use code similar to the following:</p>
-<pre>
+    <dl>
+      <dt>active</dt>
+
+      <dd>Is alarming active? If no then alarms are not raised. If yes
+      then the associated value is checked for alarm conditions.</dd>
+
+      <dt>lowAlarmLimit</dt>
+
+      <dd>If the value is &lt;= lowAlarmLimit then the severity is
+      lowAlarmSeverity.</dd>
+
+      <dt>lowWarningLimit</dt>
+
+      <dd>If the value is &gt; lowAlarmLimit and &lt;= lowWarningLimit
+      then the severity is lowWarningSeverity.</dd>
+
+      <dt>highWarningLimit</dt>
+
+      <dd>If the value is &gt;= highWarningLimit and &lt; highAlarmLimit
+      then the severity is highWarningLimit.</dd>
+
+      <dt>highAlarmLimit</dt>
+
+      <dd>If the value is &gt;= highAlarmLimit then the severity is
+      highAlarmSeverity.</dd>
+
+      <dt>lowAlarmSeverity</dt>
+
+      <dd>Severity for value that satisfies lowAlarmLimit.</dd>
+
+      <dt>lowWarningSeverity</dt>
+
+      <dd>Severity for value that satisfies lowWarningLimit.</dd>
+
+      <dt>highWarningSeverity</dt>
+
+      <dd>Severity for value that satisfies highWarningLimit.</dd>
+
+      <dt>highAlarmSeverity</dt>
+
+      <dd>Severity for value that satisfies highAlarmLimit.</dd>
+
+      <dt>hysteresis</dt>
+
+      <dd>When a value enters an alarm limit this is how much it must
+      change before is it put into a lower severity state. This prevents
+      alarm chatter.</dd>
+    </dl>
+
+    <p>Code that checks for alarms should use code similar to the
+    following:</p>
+    <pre>
     boolean active = pvActive.get();
     if(!active) return;
     double  val = pvValue.get();
     int severity = pvHighAlarmSeverity.get();
     double level = pvHighAlarmLimit.get();
     if(severity&gt;0 &amp;&amp; (val&gt;=level)) {
-    	raiseAlarm(level,val,severity,"highAlarm");
-    	return;
+        raiseAlarm(level,val,severity,"highAlarm");
+        return;
     }
     severity = pvLowAlarmSeverity.get();
     level = pvLowAlarmLimit.get();
     if(severity&gt;0 &amp;&amp; (val&lt;=level)) {
-    	raiseAlarm(level,val,severity,"lowAlarm");
-    	return;
+        raiseAlarm(level,val,severity,"lowAlarm");
+        return;
     }
     severity = pvHighWarningSeverity.get();
     level = pvHighWarningLimit.get();
     if(severity&gt;0 &amp;&amp; (val&gt;=level)) {
-    	raiseAlarm(level,val,severity,"highWarning");
-    	return;
+        raiseAlarm(level,val,severity,"highWarning");
+        return;
     }
     severity = pvLowWarningSeverity.get();
     level = pvLowWarningLimit.get();
     if(severity&gt;0 &amp;&amp; (val&lt;=level)) {
-    	raiseAlarm(level,val,severity,"lowWarning");
-    	return;
+        raiseAlarm(level,val,severity,"lowWarning");
+        return;
     }
     raiseAlarm(0,val,0,"");
 </pre>
-<p>
-<b>NOTE: </b> The current pvData implementations have a structure
-named <b>valueAlarm_t</b> instead of <b>alarmLimit_t</b>.
-<span class="nterm">valueAlarm_t</span> is similar to <span class="nterm">alarmLimit_t</span>, except that the former's alarm limit fields (<span class="term">lowAlarmLimit</span>,
-<span class="term">lowWarningLimit</span>,
-<span class="term">highWarningLimit</span> and
-<span class="term">highAlarmLimit</span>)
-can be any integer or floating point scalar type (the same type for all the limit fields in each case), rather than only double. There is also a separate form for alarm limits for boolean values. <span class="nterm">alarmLimit_t</span> is identical to the <span class="nterm">valueAlarm_t</span> for type double, except that
-the type ID of <span class="nterm">valueAlarm_t</span> is "valueAlarm_t").
-Normative types only defines alarmLimit since this is what
-clients like plot tools use.
-</p>
 
+    <p><b>NOTE:</b> The current pvData implementations have a structure
+    named <b>valueAlarm_t</b> instead of <b>alarmLimit_t</b>. <span class=
+    "nterm">valueAlarm_t</span> is similar to <span class=
+    "nterm">alarmLimit_t</span>, except that the former's alarm limit
+    fields (<span class="term">lowAlarmLimit</span>, <span class=
+    "term">lowWarningLimit</span>, <span class=
+    "term">highWarningLimit</span> and <span class=
+    "term">highAlarmLimit</span>) can be any integer or floating point
+    scalar type (the same type for all the limit fields in each case),
+    rather than only double. There is also a separate form for alarm
+    limits for boolean values. <span class="nterm">alarmLimit_t</span> is
+    identical to the <span class="nterm">valueAlarm_t</span> for type
+    double, except that the type ID of <span class=
+    "nterm">valueAlarm_t</span> is "valueAlarm_t"). Normative types only
+    defines alarmLimit since this is what clients like plot tools use.</p>
 
-<h4>alarmLimit_t[]</h4>
+    <h4>alarmLimit_t[]</h4>
 
-<p>An <span class="nterm">alarmLimit_t[]</span> is an array of alarm limit conditions. The field is an array of
-structures each describing an alarm limit. It is implemented as a pvData field of type <a
-  href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array"
-  >"structureArray"</a>, each element of which is a structure of the form <span
-class="nterm">alarmLimit_t</span> above.</p>
+    <p>An <span class="nterm">alarmLimit_t[]</span> is an array of alarm
+    limit conditions. The field is an array of structures each describing
+    an alarm limit. It is implemented as a pvData field of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array">
+    "structureArray"</a>, each element of which is a structure of the form
+    <span class="nterm">alarmLimit_t</span> above.</p>
 
+    <h4>display_t</h4>
 
-<h4>display_t</h4>
+    <p>A <span class="nterm">display_t</span> is a structure that
+    describes some typical attributes of a numerical value that are of
+    interest when displaying the value on a computer screen or similar
+    medium. The <span class="term">units</span> field SHOULD contain a
+    string representation of the physical units for the value, if any. The
+    <span class="term">description</span> field SHOULD contain a short
+    (one-line) description of what the value represents, such as can be
+    used as a label in a display. The fields <span class=
+    "term">limitLow</span> and <span class="term">limitHigh</span>
+    represent the range in between which the value should be presented as
+    adjustable.</p>
 
-<p>A <span class="nterm">display_t</span> is a structure that describes some typical attributes of
-a numerical value that are of interest when displaying the value on a computer screen
-or similar medium. The <span class="term">units</span> field SHOULD contain a string representation of the
-physical units for the value, if any. The <span class="term">description</span> field SHOULD contain a
-short (one-line) description of what the value represents, such as can be
-used as a label in a display. The fields <span class="term">limitLow</span>
-and <span class="term">limitHigh</span> represent the
-range in between which the value should be presented as adjustable.
-</p>
-<p>
-The field is a structure describing a <span class="nterm">display_t</span>.
-It is implemented as a pvData field of type
-<a
-href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure"
->"structure"</a> of type ID "display_t" with the following form: </p>
-
-<pre><span class="nterm">display_t</span> :=
+    <p>The field is a structure describing a <span class=
+    "nterm">display_t</span>. It is implemented as a pvData field of type
+    <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure">
+    "structure"</a> of type ID "display_t" with the following form:</p>
+    <pre>
+<span class="nterm">display_t</span> :=
 
 structure
     double limitLow
@@ -874,51 +1016,69 @@ structure
     string units
 </pre>
 
-<p>where:</p>
-<dl>
-  <dt>limitLow</dt>
-    <dd>The lower bound of range within which the value must be set, to be presented to a user.</dd>
-  <dt>limitHigh</dt>
-    <dd>The upper bound of range within which the value must be set, to be presented to a user.</dd>
-  <dt>description</dt>
-    <dd>A textual summary of the variable that the value quantifies.</dd>
-  <dt>format</dt>
-    <dd>A format for converting the value field to a string <span class="ed">Needs
-      work: What is display.format? What's it for and what are examples? If it's a sprintf pattern, which syntax must
-it conform to - C or Java?</span></dd>
-  <dt>units</dt>
-    <dd>The units for the value field.</dd>
-</dl>
+    <p>where:</p>
 
-<p>Where an <span class="nterm">display_t</span> structure instance is present
-in a Normative Type structure, it MUST be interpreted as referring to that
-Normative Type's field named "value". Therefore it is only used in Normative Types
-that have a single numeric "value" field.</p>
+    <dl>
+      <dt>limitLow</dt>
 
-<h4>display_t[]</h4>
+      <dd>The lower bound of range within which the value must be set, to
+      be presented to a user.</dd>
 
-<p>A <span class="nterm">display_t[]</span> is an array of <span class="nterm">display_t</span>.
-The field is an array of structures each describing the display media oriented metadata of some
-corresponding process variable value, as described by <span class="nterm">display_t</span> above.
-It is implemented as a pvData field of type <a
-  href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array"
-  >"structureArray"</a>, each element of which is a structure of the form <span
-class="nterm">display_t</span> above.</p>
+      <dt>limitHigh</dt>
 
+      <dd>The upper bound of range within which the value must be set, to
+      be presented to a user.</dd>
 
-<h4>control_t</h4>
-<p>A <span class="nterm">control_t</span> is a structure that describes a range,
-given by the interval
-(limitLow,limitHigh), within which it is expected some control software or hardware
-shall bind the control PV to which this Normative Type
-instance's value field refers as well as a minimum step change of the control PV.</p>
-<p>
-The field is a structure describing a <span class="nterm">control_t</span>. It is implemented as a pvData field of
-type <a
- href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure"
- >"structure"</a> of type ID "control_t" with the following form: </p>
+      <dt>description</dt>
 
-<pre><span class="nterm">control_t</span> :=
+      <dd>A textual summary of the variable that the value
+      quantifies.</dd>
+
+      <dt>format</dt>
+
+      <dd>A format for converting the value field to a string <span class=
+      "ed">Needs work: What is display.format? What's it for and what are
+      examples? If it's a sprintf pattern, which syntax must it conform to
+      - C or Java?</span></dd>
+
+      <dt>units</dt>
+
+      <dd>The units for the value field.</dd>
+    </dl>
+
+    <p>Where an <span class="nterm">display_t</span> structure instance is
+    present in a Normative Type structure, it MUST be interpreted as
+    referring to that Normative Type's field named "value". Therefore it
+    is only used in Normative Types that have a single numeric "value"
+    field.</p>
+
+    <h4>display_t[]</h4>
+
+    <p>A <span class="nterm">display_t[]</span> is an array of
+    <span class="nterm">display_t</span>. The field is an array of
+    structures each describing the display media oriented metadata of some
+    corresponding process variable value, as described by <span class=
+    "nterm">display_t</span> above. It is implemented as a pvData field of
+    type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array">
+    "structureArray"</a>, each element of which is a structure of the form
+    <span class="nterm">display_t</span> above.</p>
+
+    <h4>control_t</h4>
+
+    <p>A <span class="nterm">control_t</span> is a structure that
+    describes a range, given by the interval (limitLow,limitHigh), within
+    which it is expected some control software or hardware shall bind the
+    control PV to which this Normative Type instance's value field refers
+    as well as a minimum step change of the control PV.</p>
+
+    <p>The field is a structure describing a <span class=
+    "nterm">control_t</span>. It is implemented as a pvData field of type
+    <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure">
+    "structure"</a> of type ID "control_t" with the following form:</p>
+    <pre>
+<span class="nterm">control_t</span> :=
 
 structure
     double limitLow
@@ -926,230 +1086,254 @@ structure
     double minStep
 </pre>
 
-<p>where:</p>
-<dl>
-  <dt>lowLimit</dt>
-    <dd>The control low limit for the value field.</dd>
+    <p>where:</p>
+
+    <dl>
+      <dt>lowLimit</dt>
+
+      <dd>The control low limit for the value field.</dd>
+
       <dt>highLimit</dt>
-    <dd>The control high limit for the value field.</dd>
+
+      <dd>The control high limit for the value field.</dd>
+
       <dt>minStep</dt>
-    <dd>The minimum step change for the value field.</dd>
-</dl>
 
-<h4>control_t[]</h4>
+      <dd>The minimum step change for the value field.</dd>
+    </dl>
 
-<p>A <span class="nterm">control_t[]</span> is an array of <span class="nterm">control_t</span>. The field is an
-array of structures each describing the setpoint range interval of some process
- variable. It is implemented as a pvData field of type <a
-  href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array"
-  >"structureArray"</a>, each element of which is a structure of the form <span
-class="nterm">control_t</span> above.</p>
+    <h4>control_t[]</h4>
 
-<h3>Union Normative Type fields</h3>
+    <p>A <span class="nterm">control_t[]</span> is an array of
+    <span class="nterm">control_t</span>. The field is an array of
+    structures each describing the setpoint range interval of some process
+    variable. It is implemented as a pvData field of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure_array">
+    "structureArray"</a>, each element of which is a structure of the form
+    <span class="nterm">control_t</span> above.</p>
 
-<p>This subsection defines those fields of a Normative Type structure definition
- that are unions or arrays of unions.</p>
+    <h3>Union Normative Type fields</h3>
 
-<p>The union NormativeType fields are implemented with pvData fields of type <a
-href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union"
->"union"</a> or <a
-href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union_array"
->"unionArray"</a>.</p>
+    <p>This subsection defines those fields of a Normative Type structure
+    definition that are unions or arrays of unions.</p>
 
+    <p>The union NormativeType fields are implemented with pvData fields
+    of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union">
+    "union"</a> or <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union_array">
+    "unionArray"</a>.</p>The union Normative Type fields consist of the
+    variant union <span class="term">any</span> and variant union array
+    <span class="term">any[]</span> as well as a number of non-terminal
+    terms:
 
-The union Normative Type fields consist of the variant union <span class="term">any</span>
-and variant union array <span class="term">any[]</span> as well as a number of non-terminal terms:
+    <h4>any</h4>
 
-<h4>any</h4>
-<p>This is a field which is a variant union and is implemented using the pvData field type <a
-href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union"
->"union"</a>.
-</p>
+    <p>This is a field which is a variant union and is implemented using
+    the pvData field type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union">
+    "union"</a>.</p>
 
-<h4>any[]</h4>
-<p>This is a field that is an array of <span class="term">any</span>, implemented using the pvData field type
- <a
-   href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union_array"
-   >"unionArray"</a>.
-</p>
+    <h4>any[]</h4>
 
-<h4>ntunion_t</h4>
+    <p>This is a field that is an array of <span class="term">any</span>,
+    implemented using the pvData field type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union_array">
+    "unionArray"</a>.</p>
 
-<p><span class="nterm">ntunion_t</span> stands for any regular union of ntfields and is implemented using the pvData field type <a
-href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union"
->"union"</a>:
-</p>
-<pre><span class="nterm">ntunion_t</span> :=
+    <h4>ntunion_t</h4>
+
+    <p><span class="nterm">ntunion_t</span> stands for any regular union
+    of ntfields and is implemented using the pvData field type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union">
+    "union"</a>:</p>
+    <pre>
+<span class="nterm">ntunion_t</span> :=
 
 union 
-    {<span class="nterm">ntfield</span>  <span
-  class="user">field-name</span>}1+  // 1 or more ntfields.
+    {<span class="nterm">ntfield</span>  <span class=
+"user">field-name</span>}1+  // 1 or more ntfields.
 </pre>
 
+    <h4>ntunion_t[]</h4>
 
-<h4>ntunion_t[]</h4>
+    <p>An <span class="nterm">ntunion_t[]</span> stands for an array of
+    unions, where the union is any regular union of 1 or more ntfields. It
+    is implemented as a pvData field of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union_array">
+    "unionArray"</a> each element of which is a union (the same one in
+    each case) of the form <span class="nterm">ntunion_t</span> above.</p>
 
-<p>An <span class="nterm">ntunion_t[]</span> stands for an array of unions, where the union is any regular union of 1 or more ntfields. It is implemented as a pvData field of type <a
-   href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union_array"
-   >"unionArray"</a> each element of which is a union (the same one in each case) of the form <span
-  class="nterm">ntunion_t</span> above.</p>
+    <h4>union_t</h4>
 
-
-<h4>union_t</h4>
-
-<p><span class="nterm">union_t</span> stands for any regular union of pvData fields and is implemented using the pvData field of type <a
-href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union"
->"union"</a>:
-</p>
-
-<pre><span class="nterm">union_t</span> :=
+    <p><span class="nterm">union_t</span> stands for any regular union of
+    pvData fields and is implemented using the pvData field of type
+    <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union">
+    "union"</a>:</p>
+    <pre>
+<span class="nterm">union_t</span> :=
 
 union 
     {<span class="nterm">pvDataField</span>}1+ // 1 or more pvData fields.
 </pre>
-<p>where:</p>
-<dl>
-  <dt><span class="nterm">pvDataField</span></dt>
-    <dd>Stands for any pvData field.</dd>
-</dl>
 
-<h4>union_t[]</h4>
+    <p>where:</p>
 
-<p>A <span class="nterm">union_t[]</span> stands for an array of unions,
-   where the union is any regular union of 1 or more pvData fields. It is
-   implemented as a pvData field of type <a
-   href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union_array"
-   >"unionArray"</a> each element of which is a union (the same one in each
-  case) of the form <span
-  class="nterm">union_t</span> above.</p>
+    <dl>
+      <dt><span class="nterm">pvDataField</span></dt>
 
+      <dd>Stands for any pvData field.</dd>
+    </dl>
 
-<h4>anyunion_t</h4>
+    <h4>union_t[]</h4>
 
-<p><span class="nterm">anyunion_t</span> stands for a variant union or any regular union of pvData fields and is implemented using the pvData field type <a
-href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union"
->"union"</a>:
-</p>
-<pre><span class="nterm">anyunion_t</span>:=
+    <p>A <span class="nterm">union_t[]</span> stands for an array of
+    unions, where the union is any regular union of 1 or more pvData
+    fields. It is implemented as a pvData field of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union_array">
+    "unionArray"</a> each element of which is a union (the same one in
+    each case) of the form <span class="nterm">union_t</span> above.</p>
+
+    <h4>anyunion_t</h4>
+
+    <p><span class="nterm">anyunion_t</span> stands for a variant union or
+    any regular union of pvData fields and is implemented using the pvData
+    field type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union">
+    "union"</a>:</p>
+    <pre>
+<span class="nterm">anyunion_t</span>:=
 
 any | <span class="nterm">union_t</span>
 </pre>
 
-<h4>anyunion_t[]</h4>
+    <h4>anyunion_t[]</h4>
 
-<p>An <span class="nterm">anyunion_t[]</span> stands for a variant union array or a regular union
-array of any type an array of unions, where the union is any regular union of 1 or more pvData fields.
-It is implemented as a pvData field of type <a
-   href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union_array"
-   >"unionArray"</a> each element of which is a union (the same one in each case) of the form <span
-  class="nterm">anyunion_t</span> above:</p>
-
-<pre><span class="nterm">anyunion_t[]</span>:=
+    <p>An <span class="nterm">anyunion_t[]</span> stands for a variant
+    union array or a regular union array of any type an array of unions,
+    where the union is any regular union of 1 or more pvData fields. It is
+    implemented as a pvData field of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union_array">
+    "unionArray"</a> each element of which is a union (the same one in
+    each case) of the form <span class="nterm">anyunion_t</span>
+    above:</p>
+    <pre>
+<span class="nterm">anyunion_t[]</span>:=
 
 any[] | <span class="nterm">union_t[]</span>
 </pre>
 
+    <h2>Normative Type Metadata</h2>
 
-<h2>Normative Type Metadata</h2>
+    <p>Metadata are included in runtime instances of Normative Types. The
+    metadata includes to which Normative Type the structure instance
+    conforms, version information, and other data to aid efficient
+    processing, diagnostics and displays.</p>
 
-<p>Metadata are included in runtime instances of Normative Types. The metadata
-includes to which Normative Type the structure instance conforms, version
-information, and other data to aid efficient processing, diagnostics and
-displays.</p>
+    <h3>Normative Type instance self-identification</h3>
 
-<h3>Normative Type instance self-identification</h3>
+    <p>Normative Type instance data MUST identify themselves as such by
+    including an identifying string. That is the <span class=
+    "def">Normative Type Identifier</span>, or "Ntype Identifier" string
+    for short. In the pvData binding of Normative Types, this string is
+    carried in the type ID, added automatically to every pvData
+    structure.</p>
 
-<p>Normative Type instance data MUST identify themselves as such by including
- an identifying string.
- That is the <span class="def">Normative Type Identifier</span>, or
- "Ntype Identifier" string for short. 
- In the pvData binding of Normative Types, this string is carried in the type
- ID, added automatically to every pvData structure.</p>
+    <p>A Normative Type Identifier MUST be considered to be "case
+    sensitive."</p>
 
-<p>A Normative Type Identifier MUST be considered to be "case sensitive."</p>
-
-<p>The namespace Name of EPICS Normative Types (which is used as the prefix for their pvData type ID),
-is the following: </p>
-<pre>
+    <p>The namespace Name of EPICS Normative Types (which is used as the
+    prefix for their pvData type ID), is the following:</p>
+    <pre>
      epics:nt
 </pre>
 
-<p>The normative list of the Normative Type Identifiers corresponding to <a
-    href="#thisversion" >this draft</a> of the EPICS V4 Normative Types specification
-   document (this document), is given in <a href="#normative_ntype_list">Appendix
-   B</a></p>
+    <p>The normative list of the Normative Type Identifiers corresponding
+    to <a href="#thisversion">this draft</a> of the EPICS V4 Normative
+    Types specification document (this document), is given in <a href=
+    "#normative_ntype_list">Appendix B</a></p>
 
-<p>As an example, one of the simplest Normative Types is <a href="#ntscalar">
-  NTScalar</a>. It has formal Type Name "NTScalar". Therefore, the Normative Type
-  Identifier for an NTScalar,
-  is presently <span class="literal">epics:nt/NTScalar:1.0</span>.</p>
+    <p>As an example, one of the simplest Normative Types is <a href=
+    "#ntscalar">NTScalar</a>. It has formal Type Name "NTScalar".
+    Therefore, the Normative Type Identifier for an NTScalar, is presently
+    <span class="literal">epics:nt/NTScalar:1.0</span>.</p>
 
-<p>At present it is envisaged that the same namespace value shall be used for all
-   versions of this document prior to <a
-    href="http://epics-pvdata.sourceforge.net/epicsv4process.html#normative_document_development_and_publication_process"
-   >Recommendation</a>, including all Public Working Drafts of this document and
-   those marked Last Call or similar.</p>
+    <p>At present it is envisaged that the same namespace value shall be
+    used for all versions of this document prior to <a href=
+    "http://epics-pvdata.sourceforge.net/epicsv4process.html#normative_document_development_and_publication_process">
+    Recommendation</a>, including all Public Working Drafts of this
+    document and those marked Last Call or similar.</p>
 
+    <h4>pvAccess binding type identification</h4>
 
-<h4>pvAccess binding type identification</h4>
+    <p>In the EPICS v4 pvData/pvAccess binding, the structure
+    identification string (ID) of pvData structures is used to communicate
+    the Normative Type of the datum carried by the pvData structure. Every
+    pvData datum which is intended to conform to a Normative Type, MUST
+    identify the Normative Type to which it conforms through its type ID.
+    Its ID MUST have the value of its Normative Type Identifier. For
+    instance, a pvData structure conforming to NTScalar, must have ID
+    equal to "<span class="literal">epics:nt/NTScalar:1.0</span>". Every
+    EPICS V4 agent which is encoding or decoding pvData data that is
+    described by Normative Types, SHOULD examine the ID of such data, to
+    establish the Normative Type to which each datum conforms.</p>
 
-<p>In the EPICS v4 pvData/pvAccess binding, the structure identification string (ID)
-of pvData structures is used to communicate the Normative Type of the datum carried
-by the pvData structure.  Every pvData datum which is intended to conform to a
-Normative Type, MUST identify the Normative Type to which it conforms through its type ID. Its ID MUST have the value of its Normative Type Identifier. For
-instance, a pvData structure conforming to NTScalar, must have ID equal
-to "<span class="literal">epics:nt/NTScalar:1.0</span>". Every EPICS V4 agent
-which is encoding or decoding pvData data that is described by Normative Types,
-SHOULD examine the ID of such data, to establish the Normative Type to which
-each datum conforms.</p>
+    <h4>Example pvAccess/pvData binding</h4>
 
+    <p>Recall that in the pvData system, data variables are constructed in
+    two equally important parts; the <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#introspection_interfaces">
+    introspection interface</a>, in which data types are defined, and the
+    <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#data_interfaces">
+    data interface</a>, in which instance variables are created and
+    populated. The introspection interface can be used to examine an
+    existing instance, to see what fields it possesses. Getting and
+    setting values, is done through the data interface. As a programmer,
+    you have to define both parts, the introspection interface of your
+    type, and its data interface. Both the data and the introspection
+    interfaces are exchanged by pvAccess. That is, when a sender
+    constructs a data type, such as one conforming to an Normative Type,
+    plus an instance of that type, and it sends the instance to a
+    receiver, the receiver can check that the instance indeed contains the
+    member fields it should find for that type, using the type's
+    introspection interface.</p>
 
-<h4>Example pvAccess/pvData binding</h4>
+    <p>The following Java code snippets give an example of the use of a
+    pvData structure of Normative Type <a href="#ntscalar">NTScalar</a>,
+    as defined below. in this example we show code as may be included in a
+    trivial "multiplier" service, and a client of the multiplier
+    service.</p>
 
-<p>Recall that in the pvData system, data variables are constructed in two equally
-  important parts; the
-  <a href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#introspection_interfaces">introspection
-  interface</a>, in which data types are defined, and
-  the <a href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#data_interfaces">data
-  interface</a>, in which instance variables are created and populated. The introspection interface can
-  be used to examine an existing instance, to see what fields it possesses. Getting and
-  setting values, is done through the data interface. As a programmer, you
-  have to define both parts, the introspection interface of your type, and its data
-  interface. Both the data and the introspection interfaces are exchanged by
-  pvAccess. That is, when a sender constructs a data type, such as one conforming to
-  an Normative Type, plus an instance of that type, and it sends the instance to a
-  receiver, the receiver can check that the instance indeed contains the member
-  fields it should find for that type, using the type's introspection
-  interface.  </p>
+    <h5>Sender</h5>
 
-<p>The following Java code snippets give an example of the use of a
-  pvData structure of Normative Type<a href="#ntscalar"> NTScalar</a>, as defined
-  below. in this example we show code as may be included in a trivial "multiplier"
-  service, and a client of the multiplier service.</p>
+    <p>The sender typically first creates an introspection definition,
+    using the pvData introspection interfaces (Field, Structure etc.). It
+    then creates an instance of the type and populates it with the pvData
+    data interfaces (PVField, PVStructure etc.).</p>
 
-<h5>Sender</h5>
-
-<p>The sender typically first creates an introspection definition, using the pvData
-introspection interfaces (Field, Structure etc.). It then creates an instance of the
-type and populates it with the pvData data interfaces (PVField, PVStructure etc.).</p>
-
-<p class="caption">Example of creating the introspection interface of an NTScalar, as
-  may be done on a server that will be returning one. In this example, only one of
-  the optional fields of NTScalar, named "descriptor" is included, along with the
-  required field named "value".</p>
-
-<pre style="font-size:smaller">
+    <p class="caption">Example of creating the introspection interface of
+    an NTScalar, as may be done on a server that will be returning one. In
+    this example, only one of the optional fields of NTScalar, named
+    "descriptor" is included, along with the required field named
+    "value".</p>
+    <pre style="font-size:smaller">
    // Create the data type definition, using the pvData introspection interface (Structure etc.).
    FieldCreate fieldCreate = FieldFactory.getFieldCreate();
    Structure resultStructure = fieldCreate.createStructure( "epics:nt/NTScalar:1.0", 
        new String[] { "value", "descriptor" },
        new Field[] { fieldCreate.createScalar(ScalarType.pvDouble),
- 		     fieldCreate.createScalar(ScalarType.pvString) } );
+                     fieldCreate.createScalar(ScalarType.pvString) } );
 </pre>
-<p>Subsequently, the sender would create an instance of the type, and populate it.</p>
-<p class="caption">Example of creating an instance and data interface of an NTScalar, as
-  may be done on a data server, and populating it.</p>
-<pre style="font-size:smaller">
+
+    <p>Subsequently, the sender would create an instance of the type, and
+    populate it.</p>
+
+    <p class="caption">Example of creating an instance and data interface
+    of an NTScalar, as may be done on a data server, and populating
+    it.</p>
+    <pre style="font-size:smaller">
    // If a and b were arguments to this service, the following creates an instance of
    // a resultStructure, which conforms to the NTScalar Normative Type definition,
    // and populates it. It would then return this PVStructure instance.  
@@ -1157,30 +1341,32 @@ type and populates it with the pvData data interfaces (PVField, PVStructure etc.
    result.getDoubleField("value").put(a * b);
    result.getStringField("descriptor").put("The product of arguments a and b");
 </pre>
-<p>The PVStructure instance, in the example called "result" would be returned to the
-  receiver.</p>
 
-<h5>Receiver</h5>
+    <p>The PVStructure instance, in the example called "result" would be
+    returned to the receiver.</p>
 
-<p>Having in some way done a pvAccess get, the receiver could simply extract the
-primary value:</p>
-<pre style="font-size:smaller">
+    <h5>Receiver</h5>
+
+    <p>Having in some way done a pvAccess get, the receiver could simply
+    extract the primary value:</p>
+    <pre style="font-size:smaller">
    PVStructure result = easyPVA.createChannel("multiplierService").createRPC().request(request);
    double product = result.getDoubleField("value").get();
 </pre>
 
-<p>A well written receiver would check that the introspection interface (Structure
-  etc.) says that the received instance is indeed of the type it expects. It may
-  extract the data fields individually, checking their type. Importantly, it can also
-  see which optional fields it received, before attempting to access them. Here is a
-  more complete receiver example for the NTScalar sent above. This code might be in
-  the client side of the Multiplier service.</p>
+    <p>A well written receiver would check that the introspection
+    interface (Structure etc.) says that the received instance is indeed
+    of the type it expects. It may extract the data fields individually,
+    checking their type. Importantly, it can also see which optional
+    fields it received, before attempting to access them. Here is a more
+    complete receiver example for the NTScalar sent above. This code might
+    be in the client side of the Multiplier service.</p>
 
-<p class="caption">Example of a receiver of an NTScalar. The example checks that the
-returned pvData datum was an instance of an NTScalar, extracts the required value
-field, and then, if it's present, extracts the optional "descriptor" field.</p>
-
-<pre style="font-size:smaller">
+    <p class="caption">Example of a receiver of an NTScalar. The example
+    checks that the returned pvData datum was an instance of an NTScalar,
+    extracts the required value field, and then, if it's present, extracts
+    the optional "descriptor" field.</p>
+    <pre style="font-size:smaller">
    // Call the multiplier service sending the request in a structure 
    PVStructure result = easyPVA.createChannel("multiplierService").createRPC().request(request);
 
@@ -1206,62 +1392,68 @@ field, and then, if it's present, extracts the optional "descriptor" field.</p>
    System.out.println("\nWhole result structure toString =\n" + result);
 </pre>
 
-<h4>Future of type identification</h4>
+    <h4>Future of type identification</h4>
 
-<p>In future drafts of this specification, a pattern to create extensions to the
-EPICS V4 Normative Types may be presented. It may be based on a formalized link to
-the XML namespace and XML Schema system, whereby the namespace part of the Normative
-Type Identifier of a datum whose type is an extension of one of these Normative
-Types, is replaced by another namespace that extends this one through an XML Schema
-out of band. In that case, the type name part would identify a type in that other
-namespace, though it may extend a type in this namespace.</p>
+    <p>In future drafts of this specification, a pattern to create
+    extensions to the EPICS V4 Normative Types may be presented. It may be
+    based on a formalized link to the XML namespace and XML Schema system,
+    whereby the namespace part of the Normative Type Identifier of a datum
+    whose type is an extension of one of these Normative Types, is
+    replaced by another namespace that extends this one through an XML
+    Schema out of band. In that case, the type name part would identify a
+    type in that other namespace, though it may extend a type in this
+    namespace.</p>
 
- 
-<h3>Standard optional metadata fields</h3>
+    <h3>Standard optional metadata fields</h3>
 
-<p>All of the Normative Types defined below, optionally include a descriptor, alarm
-and timestamp. There is no required interpretation of these fields, and
-therefore their meaning is not further described in the Normative Type
-definitions. Additionally, Normative Types may have other optional fields, as
-defined individually below.</p>
+    <p>All of the Normative Types defined below, optionally include a
+    descriptor, alarm and timestamp. There is no required interpretation
+    of these fields, and therefore their meaning is not further described
+    in the Normative Type definitions. Additionally, Normative Types may
+    have other optional fields, as defined individually below.</p>
 
-<h4>Optional descriptor field</h4>
+    <h4>Optional descriptor field</h4>
 
-<p>An object of Normative Type may optionally include a field
-named "descriptor" and of type string, to be used to give identity, name, or
-sense information. For instance, it may be valued with the name of a device
-associated with control data, or the run number of a table of model data.</p>
-<pre>
+    <p>An object of Normative Type may optionally include a field named
+    "descriptor" and of type string, to be used to give identity, name, or
+    sense information. For instance, it may be valued with the name of a
+    device associated with control data, or the run number of a table of
+    model data.</p>
+    <pre>
 string descriptor  :opt     // Contextual information 
 </pre>
 
-<h4>Optional alarm field</h4>
+    <h4>Optional alarm field</h4>
 
-<p>An object of Normative Type may optionally include an alarm field. </p>
-<pre>
-<span class="nterm">alarm_t</span> alarm      :opt     // Control system event summary
+    <p>An object of Normative Type may optionally include an alarm
+    field.</p>
+    <pre>
+<span class=
+"nterm">alarm_t</span> alarm      :opt     // Control system event summary
 </pre>
 
-<h4>Optional timeStamp field</h4>
+    <h4>Optional timeStamp field</h4>
 
-<p>An object of Normative Type may optionally include a timeStamp
-field. </p>
-<pre>
+    <p>An object of Normative Type may optionally include a timeStamp
+    field.</p>
+    <pre>
 <span class="nterm">time_t</span> timeStamp   :opt     // Event time
 </pre>
 
+    <h2>General Normative Types</h2>
 
-<h2>General Normative Types</h2>
+    <p>The General Normative Types are for encapsulating data of any kind
+    of application or use case. Compare to <a href=
+    "#specific_normative_types">Specific Normative Types</a>, defined
+    later in this document, which are oriented to particular use
+    cases.</p>
 
-<p>The General Normative Types are for encapsulating data of any kind of
-application or use case. Compare to <a href="#specific_normative_types ">Specific
-Normative Types</a>, defined later in this document, which are oriented to
-particular use cases.</p>
+    <h3>NTScalar</h3>
 
-<h3>NTScalar</h3>
-
-<p>NTScalar is the EPICS V4 Normative Type that describes a single scalar value plus metadata:</p>
-<pre><span class="nterm">NTScalar</span> := 
+    <p>NTScalar is the EPICS V4 Normative Type that describes a single
+    scalar value plus metadata:</p>
+    <pre>
+<span class="nterm">NTScalar</span> := 
 
 structure
     <span class="nterm">scalar_t</span>    value<span class="opt">
@@ -1272,18 +1464,23 @@ structure
     <span class="nterm">control_t</span>   control     :opt</span>
 </pre>
 
-<p>where:</p>
-<dl>
-  <dt>value</dt>
-    <dd>The primary data carried by the NTScalar object. The field must be named
-      "value" and can be of any simple scalar type as defined above.</dd>
-</dl>
+    <p>where:</p>
 
-<h3>NTScalarArray</h3>
+    <dl>
+      <dt>value</dt>
 
-<p>NTScalarArray is the EPICS V4 Normative Type that describes an array of values,
-plus metadata. All the elements of the array of the same scalar type. </p>
-<pre><span class="nterm">NTScalarArray</span> := 
+      <dd>The primary data carried by the NTScalar object. The field must
+      be named "value" and can be of any simple scalar type as defined
+      above.</dd>
+    </dl>
+
+    <h3>NTScalarArray</h3>
+
+    <p>NTScalarArray is the EPICS V4 Normative Type that describes an
+    array of values, plus metadata. All the elements of the array of the
+    same scalar type.</p>
+    <pre>
+<span class="nterm">NTScalarArray</span> := 
 
 structure  
     <span class="nterm">scalar_t[]</span>  value<span class="opt">
@@ -1294,19 +1491,22 @@ structure
     <span class="nterm">control_t</span>   control     :opt</span>
 </pre>
 
-<p>where:</p>
-<dl>
-  <dt>value</dt>
-    <dd>The primary data carried by the NTScalarArray object. The field must be named
-      "value" and can be of any scalar array type as defined above.</dd>
-</dl>
+    <p>where:</p>
 
-<h3>NTEnum</h3>
+    <dl>
+      <dt>value</dt>
 
-<p>NTEnum is an EPICS V4 Normative Type that describes an enumeration (a closed set
-of possible values each described by an n-tuple).</p>
+      <dd>The primary data carried by the NTScalarArray object. The field
+      must be named "value" and can be of any scalar array type as defined
+      above.</dd>
+    </dl>
 
-<pre><span class="nterm">NTEnum</span> := 
+    <h3>NTEnum</h3>
+
+    <p>NTEnum is an EPICS V4 Normative Type that describes an enumeration
+    (a closed set of possible values each described by an n-tuple).</p>
+    <pre>
+<span class="nterm">NTEnum</span> := 
 
 structure
     <span class="nterm">enum_t</span>      value<span class="opt">
@@ -1315,21 +1515,22 @@ structure
     <span class="nterm">time_t</span>      timeStamp   :opt
     </span>
 </pre>
- 
-<p>where:</p>
-<dl>
-  <dt>value</dt>
-    <dd>The primary data carried by the NTEnum object. The field must be named
-      "value" and must be an enumeration as defined above.
-    </dd>
- </dl>
 
-<h3>NTMatrix</h3>
+    <p>where:</p>
 
-<p>NTMatrix is an EPICS V4 Normative Type used to define a matrix, specifically a
- 2-dimensional array of real numbers.</p>
- 
-<pre><span class="nterm">NTMatrix</span> := 
+    <dl>
+      <dt>value</dt>
+
+      <dd>The primary data carried by the NTEnum object. The field must be
+      named "value" and must be an enumeration as defined above.</dd>
+    </dl>
+
+    <h3>NTMatrix</h3>
+
+    <p>NTMatrix is an EPICS V4 Normative Type used to define a matrix,
+    specifically a 2-dimensional array of real numbers.</p>
+    <pre>
+<span class="nterm">NTMatrix</span> := 
 
 structure
     double[]    value
@@ -1340,129 +1541,145 @@ structure
     <span class="nterm">display_t</span>   display     :opt</span>
 </pre>
 
+    <p>where:</p>
 
-<p>where:</p>
-<dl>
-  
-  <dt>value</dt>
-    <dd>The numerical data comprising the matrix. The value is given as a single
-    array of doubles. When <span class="term">value</span> holds the data of a
-    matrix, rather than a vector, then the data MUST be laid out in "row major
-    order"; that is, all the elements of the first row, then all the elements of
-    the second row, and so on. For instance, where NTMatrix represented a 6x6 matrix,
-      element (1,2) of the matrix would be in the 2nd element of <span class="term">value</span>,
-    and
-      element (3,4) would be in the 16th element. 
-    </dd>
-    
-  <dt>dim</dt>
-    <dd>
+    <dl>
+      <dt>value</dt>
 
-      <span class="term">dim</span> indicates the dimensions of the matrix. If <span
-      class="term">dim</span> is not present, <span class="term">value</span> MUST be
-      interpreted as a vector, of length equal to the number of elements of <span
-      class="term">value</span>. If <span class="term">dim</span> is present, then it
-      must have 1 or 2 elements; its one element value or both elements values MUST
-      be > 0, and the number of elements in <span class="term">value</span> MUST be
-      equal to the product of the elements of <span class="term">dim</span>. If <span
-      class="term">dim</span> is present and contains a single element, then the
-      NTMatrix MUST be interpreted as describing a vector. A <span
-      class="term">dim</span> of 2 elements describes a matrix, where the first
-      element of <span class="term">dim</span> gives the number of rows, and the
-      second element of <span class="term">dim</span> gives the number columns. If
-      <span class="term">dim</span> is present and contains 2 elements, of which the
-      first is unity, and the second is not (therefore is >1) then the NTMatrix
-      MUST be interpreted as describing a row vector. If <span
-      class="term">dim</span> is present as contains 2 elements, of which the second
-      is unity, and the first is not (therefore is >1) then the NTMatrix MUST be
-      interpreted as describing a column vector.
-      
-    </dd>
-</dl>
+      <dd>The numerical data comprising the matrix. The value is given as
+      a single array of doubles. When <span class="term">value</span>
+      holds the data of a matrix, rather than a vector, then the data MUST
+      be laid out in "row major order"; that is, all the elements of the
+      first row, then all the elements of the second row, and so on. For
+      instance, where NTMatrix represented a 6x6 matrix, element (1,2) of
+      the matrix would be in the 2nd element of <span class=
+      "term">value</span>, and element (3,4) would be in the 16th
+      element.</dd>
 
-<p>User agents that print or otherwise render an NTMarix SHOULD print row vector,
-column vector, and non-vector matrices appropriately.</p>
+      <dt>dim</dt>
 
-<h3>NTURI</h3>
+      <dd><span class="term">dim</span> indicates the dimensions of the
+      matrix. If <span class="term">dim</span> is not present,
+      <span class="term">value</span> MUST be interpreted as a vector, of
+      length equal to the number of elements of <span class=
+      "term">value</span>. If <span class="term">dim</span> is present,
+      then it must have 1 or 2 elements; its one element value or both
+      elements values MUST be &gt; 0, and the number of elements in
+      <span class="term">value</span> MUST be equal to the product of the
+      elements of <span class="term">dim</span>. If <span class=
+      "term">dim</span> is present and contains a single element, then the
+      NTMatrix MUST be interpreted as describing a vector. A <span class=
+      "term">dim</span> of 2 elements describes a matrix, where the first
+      element of <span class="term">dim</span> gives the number of rows,
+      and the second element of <span class="term">dim</span> gives the
+      number columns. If <span class="term">dim</span> is present and
+      contains 2 elements, of which the first is unity, and the second is
+      not (therefore is &gt;1) then the NTMatrix MUST be interpreted as
+      describing a row vector. If <span class="term">dim</span> is present
+      as contains 2 elements, of which the second is unity, and the first
+      is not (therefore is &gt;1) then the NTMatrix MUST be interpreted as
+      describing a column vector.</dd>
+    </dl>
 
-<p>NTURI is the EPICS V4 Normative Type that describes a Uniform Resource Identifier
-  (URI) <a class="bib" href="#bib:uri">bib:uri</a>. Specifically, NTURI carries the
-  four parts of a "Generic URI", as described in <a class="bib"
-  href="#bib:uri">bib:uri</a> as the subset of URI that share a <cite>common syntax for
-  representing hierarchical relationships within the namespace</cite>. As such, NTURI is
-  intended to be able to encode any generic URI scheme's data. However, NTURI's
-  primary purpose in the context of EPICS, is to offer a well formed and standard
-  compliant way that EPICS agents can make a request for an identified resource from
-  a channel, especially an EPICS V4 RPC channel. See <a
-   href="http://epics-pvdata.sourceforge.net/docbuild/pvAccessJava/tip/documentation/pvAccessJava.html#channelrpc">ChannelRPC</a>.</p>
+    <p>User agents that print or otherwise render an NTMarix SHOULD print
+    row vector, column vector, and non-vector matrices appropriately.</p>
 
-<p>The
-  "pva" scheme is introduced here for EPICS V4 interactions. The pva scheme implies
-  but does not require use of the pvAccess protocol. A scheme description for Channel
-  Access (implying the ca protocol) 
-  will be added later.  What follows is a description of the syntax and semantics for
-  the pva scheme. </p>
+    <h3>NTURI</h3>
 
-<pre><span class="nterm">NTURI </span> := 
+    <p>NTURI is the EPICS V4 Normative Type that describes a Uniform
+    Resource Identifier (URI) <a class="bib" href="#bib:uri">bib:uri</a>.
+    Specifically, NTURI carries the four parts of a "Generic URI", as
+    described in <a class="bib" href="#bib:uri">bib:uri</a> as the subset
+    of URI that share a <cite>common syntax for representing hierarchical
+    relationships within the namespace</cite>. As such, NTURI is intended
+    to be able to encode any generic URI scheme's data. However, NTURI's
+    primary purpose in the context of EPICS, is to offer a well formed and
+    standard compliant way that EPICS agents can make a request for an
+    identified resource from a channel, especially an EPICS V4 RPC
+    channel. See <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvAccessJava/tip/documentation/pvAccessJava.html#channelrpc">
+    ChannelRPC</a>.</p>
+
+    <p>The "pva" scheme is introduced here for EPICS V4 interactions. The
+    pva scheme implies but does not require use of the pvAccess protocol.
+    A scheme description for Channel Access (implying the ca protocol)
+    will be added later. What follows is a description of the syntax and
+    semantics for the pva scheme.</p>
+    <pre>
+<span class="nterm">NTURI </span> := 
 
 structure 
     string scheme      
     string authority   : opt  
     string path     
     structure query    : opt  
-        {string &#124; double &#124; int &lt;field-name&gt;}0+ 
+        {string | double | int &lt;field-name&gt;}0+ 
     {&lt;field-type&gt; &lt;field-name&gt;}0+
 </pre>
 
-<h4>Interpretation of NTURI under the "pva" scheme</h4>
+    <h4>Interpretation of NTURI under the "pva" scheme</h4>
 
-<p>The following describes how the fields of the NTURI must be interpreted when the
-scheme is "pva": </p>
-<dl>
-  <dt>scheme</dt>
-<dd>The scheme name must be given. For the pva scheme, the scheme name is "pva". The
-  pva scheme implies but does not require use of the pvAccess protocol.</dd>
-  <dt>authority</dt>
-<dd>If given, then the IP name or address of an EPICS network pvAccess or channel
-  access server.</dd>
-  <dt>path</dt>
-<dd>The path gives the channel from which data is being requested.</dd>
-  <dt>query</dt>
-<dd>A name value system for passing parameters. The types of the argument value MUST
-  be drawn from the following restricted set of scalar types: double, int, or
-  string.</dd>
-<dt>&lt;field-type&gt;</dt>
-<dd>Zero or more pvData Fields whose type are not defined until runtime, may be
-  added to an NTURI by an agent creating an NTURI. This is the mechanism by which
-  complex data may be sent to a channel. For instance a table of magnet
-  setpoints.</dd>
-</dl>
+    <p>The following describes how the fields of the NTURI must be
+    interpreted when the scheme is "pva":</p>
 
-<p> The channel name given in the path MAY BE the name of an RPC
-  channel. In that case, it's important to note that this specification makes no
-  normative statement about where in the NTURI is encoded the name of the entity
-  <em>about which</em> the RPC service is being called. For instance, an archive
-service, that gives the historical values of channels, may advertise itself
-as being on a single channel called say "archive service" (so the NTURI path field in 
-that case would 
-  be set to "archiveservice", and in that case, the name
-  of the EPICS channel about which archive data is wanted might well be encoded into
-  one of the NTURI's query field parameters. Alternatively, the archive service might advertise a
-  number of channels, each named perhaps after the channels whose historical data is being
-  requested. For instance, a path may be "quad45:bdes;history", if that was the
-  name of one of the channels offered by the archive service. An example of this second form is
-  given below. 
-</p>
+    <dl>
+      <dt>scheme</dt>
 
-<p>Use of NTURI may be explained by example. The following is an example client side
-  of Channel RPC exchange, where a notional archive service, is asked for the data
-  for a PV between two points in time. In this example, the archive service is
-  advertising the channel name "quad45:bdes;history". Presumably, that service knows
-the archive history of a (second) channel, named probably, "quad45:bdes".</p>
+      <dd>The scheme name must be given. For the pva scheme, the scheme
+      name is "pva". The pva scheme implies but does not require use of
+      the pvAccess protocol.</dd>
 
-<p>Construct the introspection interface (i.e. type definition) of the NTURI
-  conformant structure that will be used to make requests to the archive service.</p>
-<pre style="font-size:smaller">
+      <dt>authority</dt>
+
+      <dd>If given, then the IP name or address of an EPICS network
+      pvAccess or channel access server.</dd>
+
+      <dt>path</dt>
+
+      <dd>The path gives the channel from which data is being
+      requested.</dd>
+
+      <dt>query</dt>
+
+      <dd>A name value system for passing parameters. The types of the
+      argument value MUST be drawn from the following restricted set of
+      scalar types: double, int, or string.</dd>
+
+      <dt>&lt;field-type&gt;</dt>
+
+      <dd>Zero or more pvData Fields whose type are not defined until
+      runtime, may be added to an NTURI by an agent creating an NTURI.
+      This is the mechanism by which complex data may be sent to a
+      channel. For instance a table of magnet setpoints.</dd>
+    </dl>
+
+    <p>The channel name given in the path MAY BE the name of an RPC
+    channel. In that case, it's important to note that this specification
+    makes no normative statement about where in the NTURI is encoded the
+    name of the entity <em>about which</em> the RPC service is being
+    called. For instance, an archive service, that gives the historical
+    values of channels, may advertise itself as being on a single channel
+    called say "archive service" (so the NTURI path field in that case
+    would be set to "archiveservice", and in that case, the name of the
+    EPICS channel about which archive data is wanted might well be encoded
+    into one of the NTURI's query field parameters. Alternatively, the
+    archive service might advertise a number of channels, each named
+    perhaps after the channels whose historical data is being requested.
+    For instance, a path may be "quad45:bdes;history", if that was the
+    name of one of the channels offered by the archive service. An example
+    of this second form is given below.</p>
+
+    <p>Use of NTURI may be explained by example. The following is an
+    example client side of Channel RPC exchange, where a notional archive
+    service, is asked for the data for a PV between two points in time. In
+    this example, the archive service is advertising the channel name
+    "quad45:bdes;history". Presumably, that service knows the archive
+    history of a (second) channel, named probably, "quad45:bdes".</p>
+
+    <p>Construct the introspection interface (i.e. type definition) of the
+    NTURI conformant structure that will be used to make requests to the
+    archive service.</p>
+    <pre style="font-size:smaller">
 // Construct an NTURI for making a request to a service that understands 
 // query arguments named "starttime" and "endtime".
 FieldCreate fieldCreate = FieldFactory.getFieldCreate();
@@ -1477,42 +1694,41 @@ Structure uriStructure =
                        queryStructure } );
 
 </pre>
-<p>Populate our uriStructure (conformant to NTURI) with a specific request.</p>
-<pre style="font-size:smaller">
+
+    <p>Populate our uriStructure (conformant to NTURI) with a specific
+    request.</p>
+    <pre style="font-size:smaller">
 // Get a EasyPVA singleton.
 EasyPVA easyPVA = EasyPVAFactory.get();
 
 // Construct an NTURI with which to ask for the archive data of quad45:bdes
 PVStructure request = PVDataFactory.getPVDataCreate().
-	createPVStructure(uriStructure);
+        createPVStructure(uriStructure);
 request.getStringField("path").put("quad45:bdes;history");
 PVStructure query = request.getStructureField("query");
 query.getStringField("starttime").put("2011-09-16T02.12.55");
 query.getStringField("endtime").put("2011-09-16T10.01.03");
-		
+                
 // Ask for the data, using the NTURI
 PVStructure result = easyPVA.createChannel(request.getStringField("path").get()).createRPC().request(request);
 if ( result != null )
     System.out.println("The URI request structure:\n" + request
-		+"\n\nResulted in:\n" + result);
+                +"\n\nResulted in:\n" + result);
 </pre>
-<p>The server side is not illustrated, but clearly its code would have registered a
-  number of ChannelRPC services, each named after the PV whose historical data it
-  offered.
- </p>
 
+    <p>The server side is not illustrated, but clearly its code would have
+    registered a number of ChannelRPC services, each named after the PV
+    whose historical data it offered.</p>
 
+    <h3>NTNameValue</h3>
 
-<h3>NTNameValue</h3>
+    <p>NTNameValue is the EPICS V4 Normative Type that describes a system
+    of name and scalar values.</p>
 
-<p>NTNameValue is the EPICS V4 Normative Type that describes a system of name and
-scalar values. </p>
-
-
-<p>Use cases: In a school, a single NTNamedValue might describe the grades from a
- number of classes for one student. </p>
-
-<pre><span class="nterm">NTNameValue</span> := 
+    <p>Use cases: In a school, a single NTNamedValue might describe the
+    grades from a number of classes for one student.</p>
+    <pre>
+<span class="nterm">NTNameValue</span> := 
 
 structure
     string[]     name
@@ -1522,95 +1738,120 @@ structure
     <span class="nterm">time_t</span>       timeStamp    :opt</span>
 </pre>
 
-<p>where:</p>
-<dl>
-  <dt>name</dt>
-    <dd>The keys associated with the  <span class="term">value</span> field. Each
-      element of <span class="term">name</span>  identifies the
-      same indexed element of the <span class="term">value</span> field, using a
-      string label.</dd>
-  <dt>value</dt>
-    <dd>The data values, each element of which is associated with the correspondingly
-      indexed element of the  <span class="term">name</span> field.</dd>
-</dl>
+    <p>where:</p>
 
-<p>Each name (or "key") in the array of names, MUST be interpreted as being associated with its same
-indexed element of the <span class="term">value</span> array. </p>
+    <dl>
+      <dt>name</dt>
 
+      <dd>The keys associated with the <span class="term">value</span>
+      field. Each element of <span class="term">name</span> identifies the
+      same indexed element of the <span class="term">value</span> field,
+      using a string label.</dd>
 
-<h3>NTTable</h3>
+      <dt>value</dt>
 
-<p>NTTable is the EPICS V4 Normative Type suitable for column-oriented tabular datasets.</p>
+      <dd>The data values, each element of which is associated with the
+      correspondingly indexed element of the <span class=
+      "term">name</span> field.</dd>
+    </dl>
 
-<p>An NTTable is made up of a number of arrays. Each array can be thought of as a
-column. Each array MUST be of a scalar type and all the arrays MUST be of the same
-length. Each array may be of a different scalar type. The set of the <em>i</em>th array
-members of all the columns make up one row, or n-tuple. The number of elements of <span
-class="term">labels</span> MUST be equal to the number of fields of <span
-class="term">value</span>.</p>
+    <p>Each name (or "key") in the array of names, MUST be interpreted as
+    being associated with its same indexed element of the <span class=
+    "term">value</span> array.</p>
 
-<p>Use case examples: a table of the Twiss parameters of all the lattice elements in an
-accelerator section. Another example, where the columns might vary call-to-call to an
-RPC setting, would be that of an EPICS V4 SQL database service. In that example one
-NTTable returned by the service would contain the tabular results of a SQL SELECT,
-essentially a recoded JDBC or ODBC ResultSet - see the <a class="bib"
-href="#bib:rdbservice">rdbservice</a>. </p>
+    <h3>NTTable</h3>
 
-<pre><span class="nterm">NTTable</span> := 
+    <p>NTTable is the EPICS V4 Normative Type suitable for column-oriented
+    tabular datasets.</p>
+
+    <p>An NTTable is made up of a number of arrays. Each array can be
+    thought of as a column. Each array MUST be of a scalar type and all
+    the arrays MUST be of the same length. Each array may be of a
+    different scalar type. The set of the <em>i</em>th array members of
+    all the columns make up one row, or n-tuple. The number of elements of
+    <span class="term">labels</span> MUST be equal to the number of fields
+    of <span class="term">value</span>.</p>
+
+    <p>Use case examples: a table of the Twiss parameters of all the
+    lattice elements in an accelerator section. Another example, where the
+    columns might vary call-to-call to an RPC setting, would be that of an
+    EPICS V4 SQL database service. In that example one NTTable returned by
+    the service would contain the tabular results of a SQL SELECT,
+    essentially a recoded JDBC or ODBC ResultSet - see the <a class="bib"
+    href="#bib:rdbservice">rdbservice</a>.</p>
+    <pre>
+<span class="nterm">NTTable</span> := 
 
 structure
     string[]   labels              // Very short text describing each field below, i.e. column labels
     structure  value
-        {<span class="nterm">scalar_t</span>[]  <span
-  class="user">colname</span>}0+ // 0 or more scalar array instances, the column values.<span class="opt">
+        {<span class="nterm">scalar_t</span>[]  <span class=
+"user">colname</span>}0+ // 0 or more scalar array instances, the column values.<span class="opt">
     string     descriptor  : opt
     <span class="nterm">alarm_t</span>    alarm       : opt
     <span class="nterm">time_t</span>     timeStamp   : opt</span>
 </pre>
 
-<p>where:</p>
-<dl>
-  <dt>labels</dt>
-  <dd>The table column headings are given by the <span class="term">labels</span> field.
-      Each column heading given as one element of the array of strings.
-    </dd>
-    <dt>value</dt>
-    <dd>The data of the table are encoded in a structure named <span class="term">value</span>. We call the columnar data field
-    "value" (rather than, for instance, "columndata") so that the primary field of the
-      type is named the same for all Normative Types, and so to help general purpose clients
-      identify the primary field.</dd>
-</dl>
+    <p>where:</p>
 
-<h4>Interpretation</h4>
+    <dl>
+      <dt>labels</dt>
 
-<p>An NTTable instance represents a table of data. The column data is given in scalar arrays in the structure field <span class="term">value</span>, and the column headings are given in field <span class="term">labels</span>. Each <span class="user">colname</span> scalar array
-field of <span class="term">value</span> contains the data for the column corresponding to the same indexed element of
-the <span class="term">labels</span> field.  Agents SHOULD use the elements of <span
-class="term">labels</span> as the column headings. <span class="nonnorm">There is no normative requirement that the
-field names of <span class="term">value</span> match the strings in <span class="term">labels</span></span>. </p>
+      <dd>The table column headings are given by the <span class=
+      "term">labels</span> field. Each column heading given as one element
+      of the array of strings.</dd>
 
-<p>Note that the above description is given in terms of a table and its columns,
-but there is nothing specifically columnar about how this data may be rendered. A
-user may choose to print the fields row wise if, for instance, if there are many fields in <span class="term">value</span>,
-but each has only length 1 or 2. For example, if one wanted to give all the scalar data related
-to one device, then one might use an NTTable rendered in such a way.
-</p>
+      <dt>value</dt>
 
-<h4>Validation</h4>
+      <dd>The data of the table are encoded in a structure named
+      <span class="term">value</span>. The columnar data field is named
+      "value" (rather than, for instance, "columndata") so that the
+      primary field of the type is named the same for all Normative Types. 
+      That helps general purpose clients identify the primary
+      field of any Normative Type instance.</dd>
+    </dl>
 
-<p>The number of <span class="nterm">scalar_t[]</span> fields in the value
-structure, and the length of <span class="term">labels</span> MUST be the same. All
-<span class="nterm">scalar_t[]</span> fields in the <span class="term">value</span> structure
-MUST have the same length, which is the number of "rows" in the table.</p>
+    <h4>Interpretation</h4>
 
-<h3>NTAttribute</h3>
+    <p>An NTTable instance represents a table of data. The column data is
+    given in scalar arrays in the structure field <span class=
+    "term">value</span>, and the column headings are given in field
+    <span class="term">labels</span>. Each <span class=
+    "user">colname</span> scalar array field of <span class=
+    "term">value</span> contains the data for the column corresponding to
+    the same indexed element of the <span class="term">labels</span>
+    field. Agents SHOULD use the elements of <span class=
+    "term">labels</span> as the column headings. <span class=
+    "nonnorm">There is no normative requirement that the field names of
+    <span class="term">value</span> match the strings in <span class=
+    "term">labels</span></span>.</p>
 
-<p>NTAttribute is the EPICS V4 Normative Type for a named attribute of any type. It is is essentially
-a key-value pair which optionally can be tagged with additional strings.</p>
-<p>This allows, for example, a collection of attributes to be queried on the basis of attribute
- name or tags.</p>
+    <p>Note that the above description is given in terms of a table and
+    its columns, but there is nothing specifically columnar about how this
+    data may be rendered. A user may choose to print the fields row wise
+    if, for instance, if there are many fields in <span class=
+    "term">value</span>, but each has only length 1 or 2. For example, if
+    one wanted to give all the scalar data related to one device, then one
+    might use an NTTable rendered in such a way.</p>
 
-<pre><span class="nterm">NTAttribute</span> := 
+    <h4>Validation</h4>
+
+    <p>The number of <span class="nterm">scalar_t[]</span> fields in the
+    value structure, and the length of <span class="term">labels</span>
+    MUST be the same. All <span class="nterm">scalar_t[]</span> fields in
+    the <span class="term">value</span> structure MUST have the same
+    length, which is the number of "rows" in the table.</p>
+
+    <h3>NTAttribute</h3>
+
+    <p>NTAttribute is the EPICS V4 Normative Type for a named attribute of
+    any type. It is is essentially a key-value pair which optionally can
+    be tagged with additional strings.</p>
+
+    <p>This allows, for example, a collection of attributes to be queried
+    on the basis of attribute name or tags.</p>
+    <pre>
+<span class="nterm">NTAttribute</span> := 
 
 structure
     string    name              
@@ -1621,44 +1862,52 @@ structure
     <span class="nterm">time_t</span>    timeStamp     : opt</span>
 </pre>
 
-<p>where:</p>
-<dl>
-  <dt>name</dt>
-    <dd>The name of the attribute. The "key" of the key-value pair.
-    </dd>
-    <dt>value</dt>
-    <dd>The value of the attribute. The "value" of a key-value pair.</dd>
-    <dt>tags</dt>
-    <dd>Additional tags that an attribute can carry.</dd>
-</dl>
+    <p>where:</p>
 
-<h2>Specific Normative Types</h2>
+    <dl>
+      <dt>name</dt>
 
+      <dd>The name of the attribute. The "key" of the key-value pair.</dd>
 
-<p>The "Specific Normative Types" below are types oriented towards
-application-level scientific and engineering use cases. Compare to <a
-href="#general_normative_types">General Normative Types</a> defined above. The
-currently defined types are each described in a section below.</p>
+      <dt>value</dt>
 
-<p>Unless otherwise stated:</p>
-<ul>
-  <li>Times MUST be in seconds</li>
-  <li>Frequencies MUST be in Hz.</li>
-</ul>
+      <dd>The value of the attribute. The "value" of a key-value
+      pair.</dd>
 
+      <dt>tags</dt>
 
-<h3>NTMultiChannel</h3>
+      <dd>Additional tags that an attribute can carry.</dd>
+    </dl>
 
-<p>NTMultiChannel is an EPICS V4 Normative Type that aggregates an array of 
-values from different EPICS Process Variable (PV) channel sources, not
-necessarily of the same type, into a single variable. </p>
+    <h2>Specific Normative Types</h2>
 
+    <p>The "Specific Normative Types" below are types oriented towards
+    application-level scientific and engineering use cases. Compare to
+    <a href="#general_normative_types">General Normative Types</a> defined
+    above. The currently defined types are each described in a section
+    below.</p>
 
-<pre><span class="nterm">NTMultiChannel</span> := 
+    <p>Unless otherwise stated:</p>
+
+    <ul>
+      <li>Times MUST be in seconds</li>
+
+      <li>Frequencies MUST be in Hz.</li>
+    </ul>
+
+    <h3>NTMultiChannel</h3>
+
+    <p>NTMultiChannel is an EPICS V4 Normative Type that aggregates an
+    array of values from different EPICS Process Variable (PV) channel
+    sources, not necessarily of the same type, into a single variable.</p>
+    <pre>
+<span class="nterm">NTMultiChannel</span> := 
 
 structure
-    <span class="nterm">anyunion_t[]</span>  value              // The channel values
-    string[]      channelName        // The channel names    <span class="opt">
+    <span class=
+"nterm">anyunion_t[]</span>  value              // The channel values
+    string[]      channelName        // The channel names    <span class=
+"opt">
     string        descriptor         :opt
     <span class="nterm">alarm_t</span>       alarm              :opt
     <span class="nterm">time_t</span>        timeStamp          :opt
@@ -1667,55 +1916,74 @@ structure
     string[]      message            :opt
     long[]        secondsPastEpoch   :opt
     int[]         nanoseconds        :opt
-    int[]         userTag            :opt</span></pre>
+    int[]         userTag            :opt</span>
+</pre>
 
-<p>where:</p>
-<dl>
-  <dt>value</dt>
-    <dd>The value from each channel.</dd>
-  <dt>channelName</dt>
-      <dd>The name of each channel.
-	</dd>
-  <dt>alarm</dt>
-     <dd>The alarm associated with the NTMultiChannel itself.
-      <span class="term">severity</span>, <span class="term">status</span>, and <span class="term">message</span> show the alarm for each channel.
-      </dd>
-  <dt>timeStamp</dt>
-     <dd>The timestamp associated with the NTMultiChannel itself.
-      <span class="term">secondsPastEpoch</span>, <span class="term">nanoseconds</span> and <span class="term">userTag</span> show the timestamp for each channel.
-      </dd>
-  <dt>severity</dt>
-    <dd>The alarm severity associated with each channel.</dd>
-  <dt>status</dt>
-    <dd>The alarm status associated with each channel.</dd>
-  <dt>message</dt>
-    <dd>The alarm message associated with each channel.</dd>
-  <dt>secondsPastEpoch</dt>
-    <dd>The <span class="term">secondsPastEpoch</span> field of the timestamp associated with each channel.</dd>
-  <dt>nanoseconds</dt>
-    <dd>The <span class="term">nanoseconds</span> field of the timestamp associated with each channel.</dd>
-  <dt>userTag</dt>
-    <dd>The <span class="term">userTag</span> field of the timestamp associated with each channel.</dd>
-</dl>
+    <p>where:</p>
 
+    <dl>
+      <dt>value</dt>
 
-<h3>NTNDArray</h3>
+      <dd>The value from each channel.</dd>
 
-<p>
-NTNDArray is an EPICS Version 4 Normative Type designed to encode data from detectors
-and cameras, especially
-<a
- href="http://cars9.uchicago.edu/software/epics/areaDetector.html">areaDetector</a> applications.
+      <dt>channelName</dt>
 
-The type is heavily modeled on areaDetector's <a
- href="http://cars9.uchicago.edu/software/epics/areaDetectorDoxygenHTML/class_n_d_array.html">NDArray</a> class.
+      <dd>The name of each channel.</dd>
 
-One NTNDArray gives one frame.
-</p>
+      <dt>alarm</dt>
 
-<p>The definition of NTNDArray in full is:
-</p>
-<pre><span class="nterm">NTNDArray</span> := 
+      <dd>The alarm associated with the NTMultiChannel itself.
+      <span class="term">severity</span>, <span class=
+      "term">status</span>, and <span class="term">message</span> show the
+      alarm for each channel.</dd>
+
+      <dt>timeStamp</dt>
+
+      <dd>The timestamp associated with the NTMultiChannel itself.
+      <span class="term">secondsPastEpoch</span>, <span class=
+      "term">nanoseconds</span> and <span class="term">userTag</span> show
+      the timestamp for each channel.</dd>
+
+      <dt>severity</dt>
+
+      <dd>The alarm severity associated with each channel.</dd>
+
+      <dt>status</dt>
+
+      <dd>The alarm status associated with each channel.</dd>
+
+      <dt>message</dt>
+
+      <dd>The alarm message associated with each channel.</dd>
+
+      <dt>secondsPastEpoch</dt>
+
+      <dd>The <span class="term">secondsPastEpoch</span> field of the
+      timestamp associated with each channel.</dd>
+
+      <dt>nanoseconds</dt>
+
+      <dd>The <span class="term">nanoseconds</span> field of the timestamp
+      associated with each channel.</dd>
+
+      <dt>userTag</dt>
+
+      <dd>The <span class="term">userTag</span> field of the timestamp
+      associated with each channel.</dd>
+    </dl>
+
+    <h3>NTNDArray</h3>
+
+    <p>NTNDArray is an EPICS Version 4 Normative Type designed to encode
+    data from detectors and cameras, especially <a href=
+    "http://cars9.uchicago.edu/software/epics/areaDetector.html">areaDetector</a>
+    applications. The type is heavily modeled on areaDetector's <a href=
+    "http://cars9.uchicago.edu/software/epics/areaDetectorDoxygenHTML/class_n_d_array.html">
+    NDArray</a> class. One NTNDArray gives one frame.</p>
+
+    <p>The definition of NTNDArray in full is:</p>
+    <pre>
+<span class="nterm">NTNDArray</span> := 
 
 structure
     <span class="nterm">value_t</span>       value
@@ -1732,11 +2000,13 @@ structure
     <span class="nterm">display_t</span>     display     :opt</span>
 </pre>
 
-<p>The meaning of the above fields, the definition of <span class="nterm">value_t</span>
-and of <span class="nterm">dimension_t</span> and the additional requirements for NDAttribute
-are described below. To simplify this the NTNDArray can be regarded as being composed of the
-following parts:</p>
-<pre><span class="nterm">NTNDArray</span> := 
+    <p>The meaning of the above fields, the definition of <span class=
+    "nterm">value_t</span> and of <span class="nterm">dimension_t</span>
+    and the additional requirements for NDAttribute are described below.
+    To simplify this the NTNDArray can be regarded as being composed of
+    the following parts:</p>
+    <pre>
+<span class="nterm">NTNDArray</span> := 
 
 structure
     <span class="nterm">Image data and codec</span>
@@ -1747,29 +2017,37 @@ structure
     <span class="nterm">Optional fields</span>
 </pre>
 
-<p>Each of these will be discussed separately.</p>
+    <p>Each of these will be discussed separately.</p>
 
-<h4>Image data and codec</h4>
-<p>The     <span class="nterm">Image data and codec</span> parts of an NTNDArray are composed of the
-following fields:</p>
-<pre>    <span class="nterm">value_t</span> value // Image data  
+    <h4>Image data and codec</h4>
+
+    <p>The <span class="nterm">Image data and codec</span> parts of an
+    NTNDArray are composed of the following fields:</p>
+    <pre>
+    <span class="nterm">value_t</span> value // Image data  
     <span class="nterm">codec_t</span> codec // Codec
 </pre>
 
-<p>where:</p> 
-<dl>
-  <dt>value</dt>
-    <dd>An array which encodes an N-dimensional array containing the data for the image itself.</dd>
-  <dt>codec</dt>
-    <dd>Information on the how the data in value encodes the N-dimensional array.</dd>
-</dl>
+    <p>where:</p>
 
-<p>A <span class="nterm">value_t</span> 
-  is implemented as a pvData Field of type <a
-   href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union"
-   >"union"</a> with the following form:</p>
+    <dl>
+      <dt>value</dt>
 
-<pre><span class="nterm">value_t</span>:=
+      <dd>An array which encodes an N-dimensional array containing the
+      data for the image itself.</dd>
+
+      <dt>codec</dt>
+
+      <dd>Information on the how the data in value encodes the
+      N-dimensional array.</dd>
+    </dl>
+
+    <p>A <span class="nterm">value_t</span> is implemented as a pvData
+    Field of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_union">
+    "union"</a> with the following form:</p>
+    <pre>
+<span class="nterm">value_t</span>:=
 
 union
     boolean[] booleanValue
@@ -1785,12 +2063,11 @@ union
     double[]  doubleValue
 </pre>
 
-<p>A <span class="nterm">codec_t</span> 
-  is implemented as a pvData Field of type <a
-   href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure"
-   >"structure"</a> of type ID "codec_t" with the following form:</p>
-
-<pre>
+    <p>A <span class="nterm">codec_t</span> is implemented as a pvData
+    Field of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure">
+    "structure"</a> of type ID "codec_t" with the following form:</p>
+    <pre>
 <span class="nterm">codec_t</span> :=
 
 structure
@@ -1798,104 +2075,132 @@ structure
     any    parameters
 </pre>
 
-<p>where:</p>
-<dl>
-  <dt>name</dt>
-    <dd>The encoding scheme, e.g. the codec in the case of compressed data.</dd>
-  <dt>parameters</dt>
-    <dd>Any additional information required to interpret the data.</dd>
-</dl>
-<p>
-The <span class="term">value</span> field stores a scalar array of one of the scalar types
-permitted by the definition of <span class="term">value</span> above whose value MUST represent
-an N-dimensional scalar array of one of the permitted scalar types whose dimensions are given by
-the <span class="term">dimension</span> field (see below). Note that the scalar type of the array
-stored in <span class="term">value</span> MAY be different from that of the array it represents.
-</p>
-<p>
-The <span class="term">codec</span> field is a structure which describes how the N-dimensional
-scalar array is represented by the value of the scalar array stored in the
-<span class="term">value</span> field.
-</p>
-<p>
-The <span class="term">name</span> field of the <span class="term">codec</span> field
-(<span class="term">codec.name</span>) is a string which identifies the scheme by which the
-data in <span class="term">value</span> is encoded, such as an algorithm used to compress the data.
-If it is not the empty string, the value of the <span class="term">codec.name</span> field SHOULD
-be namespace qualified. 
-</p>
-<p>
-The <span class="term">parameters</span> field of the <span class="term">codec</span> field
-(<span class="term">codec.parameters</span>) is a field which contains any additional information required to interpret the data in <span class="term">value</span>. The format and meaning of
-<span class="term">codec.parameters</span> is <span class="term">codec.name</span>-dependent.
-</p>
+    <p>where:</p>
 
-<p>
-When the value of the <span class="term">codec.name</span> field is the empty string the data in
-<span class="term">value</span> MUST represent an N-dimensional array of the same scalar type as the
-scalar array stored in <span class="term">value</span> whose dimensions are given by the
-<span class="term">dimension</span> field. The elements of the array stored in
-<span class="term">value</span> MUST be the elements of the N-dimensional array laid out
-in row major order. In this case the length of the <span class="term">value</span> array
-SHOULD equal the product of the dimensions and MUST be greater than or equal to it.
-</p>
-<p>
-When the <span class="term">codec.name</span> field value is not the empty string the interpretation
-of the data in the <span class="term">value</span> field is dependent on the
-<span class="term">codec</span> field. Any requirements on the type or length of the array
-stored in the <span class="term">value</span> field are <span class="term">codec</span>-dependent.
-</p>
-<p>Any endianness information associated with a compression algorithm or other encoding SHOULD be
-encoded via the <span class="term">codec</span> field, either through the
-<span class="term">codec.name</span> or <span class="term">codec.parameters</span> fields.
-</p>
-<p>Similarly any information required to determine the scalar type of the N-dimensional array when
-the value of <span class="term">codec.name</span> field  is non-empty SHOULD also be encoded in
-the <span class="term">codec</span> field.
-</p>
-<p>Except for the above requirements, the meaning of the <span class="term">codec</span> field,
-beyond the case of the empty <span class="term">codec.name</span> string, is not currently specified.</p>
+    <dl>
+      <dt>name</dt>
 
-<h4>Data sizes</h4>
+      <dd>The encoding scheme, e.g. the codec in the case of compressed
+      data.</dd>
 
-<p>The     <span class="nterm">Data sizes</span> part of an NTNDArray is composed of the following fields:</p>
-<pre>    long compressedSize
+      <dt>parameters</dt>
+
+      <dd>Any additional information required to interpret the data.</dd>
+    </dl>
+
+    <p>The <span class="term">value</span> field stores a scalar array of
+    one of the scalar types permitted by the definition of <span class=
+    "term">value</span> above whose value MUST represent an N-dimensional
+    scalar array of one of the permitted scalar types whose dimensions are
+    given by the <span class="term">dimension</span> field (see below).
+    Note that the scalar type of the array stored in <span class=
+    "term">value</span> MAY be different from that of the array it
+    represents.</p>
+
+    <p>The <span class="term">codec</span> field is a structure which
+    describes how the N-dimensional scalar array is represented by the
+    value of the scalar array stored in the <span class=
+    "term">value</span> field.</p>
+
+    <p>The <span class="term">name</span> field of the <span class=
+    "term">codec</span> field (<span class="term">codec.name</span>) is a
+    string which identifies the scheme by which the data in <span class=
+    "term">value</span> is encoded, such as an algorithm used to compress
+    the data. If it is not the empty string, the value of the <span class=
+    "term">codec.name</span> field SHOULD be namespace qualified.</p>
+
+    <p>The <span class="term">parameters</span> field of the <span class=
+    "term">codec</span> field (<span class="term">codec.parameters</span>)
+    is a field which contains any additional information required to
+    interpret the data in <span class="term">value</span>. The format and
+    meaning of <span class="term">codec.parameters</span> is <span class=
+    "term">codec.name</span>-dependent.</p>
+
+    <p>When the value of the <span class="term">codec.name</span> field is
+    the empty string the data in <span class="term">value</span> MUST
+    represent an N-dimensional array of the same scalar type as the scalar
+    array stored in <span class="term">value</span> whose dimensions are
+    given by the <span class="term">dimension</span> field. The elements
+    of the array stored in <span class="term">value</span> MUST be the
+    elements of the N-dimensional array laid out in row major order. In
+    this case the length of the <span class="term">value</span> array
+    SHOULD equal the product of the dimensions and MUST be greater than or
+    equal to it.</p>
+
+    <p>When the <span class="term">codec.name</span> field value is not
+    the empty string the interpretation of the data in the <span class=
+    "term">value</span> field is dependent on the <span class=
+    "term">codec</span> field. Any requirements on the type or length of
+    the array stored in the <span class="term">value</span> field are
+    <span class="term">codec</span>-dependent.</p>
+
+    <p>Any endianness information associated with a compression algorithm
+    or other encoding SHOULD be encoded via the <span class=
+    "term">codec</span> field, either through the <span class=
+    "term">codec.name</span> or <span class="term">codec.parameters</span>
+    fields.</p>
+
+    <p>Similarly any information required to determine the scalar type of
+    the N-dimensional array when the value of <span class=
+    "term">codec.name</span> field is non-empty SHOULD also be encoded in
+    the <span class="term">codec</span> field.</p>
+
+    <p>Except for the above requirements, the meaning of the <span class=
+    "term">codec</span> field, beyond the case of the empty <span class=
+    "term">codec.name</span> string, is not currently specified.</p>
+
+    <h4>Data sizes</h4>
+
+    <p>The <span class="nterm">Data sizes</span> part of an NTNDArray is
+    composed of the following fields:</p>
+    <pre>
+    long compressedSize
     long uncompressedSize
 </pre>
-<p>where:</p> 
-<dl>
-  <dt>compressedSize</dt>
-    <dd>The size of the data in bytes after any compression or other encoding.</dd>
-  <dt>uncompressedSize</dt>
-    <dd>The size of the data in bytes before any compression or other encoding.</dd>
-</dl>
-<p>
-The value of the <span class="term">compressedSize</span> field MUST be equal to the product of
-the length of the scalar array field stored in the <span class="term">value</span> field and the
-size of the scalar type in bytes (i.e. 1, 2, 4 or 8 for signed or unsigned byte, short, int
-or long respectively, 1 for boolean, 4 for float and 8 for double).
-</p>
-<p>
-The value of the <span class="term">uncompressedSize</span> field MUST be equal to the product of
-the value of the <span class="term">size</span> field of each element  in the structure
-array <span class="term">dimension</span> field (described below) and the size in bytes of
-the scalar type of the scalar array represented by <span class="term">value</span>. If the
-number of elements of the <span class="term">dimension</span> field is 0 the value of the
-<span class="term">uncompressedSize</span> MUST be 0. 
-</p>
 
-<h4>Dimensions</h4>
+    <p>where:</p>
 
-<p>The <span class="nterm">Dimensions</span> part of an NTNDArray is composed of the
-<span class="term">dimension</span> field 
-</p>
-<pre>    <span class="nterm">dimension_t[]</span> dimension
+    <dl>
+      <dt>compressedSize</dt>
+
+      <dd>The size of the data in bytes after any compression or other
+      encoding.</dd>
+
+      <dt>uncompressedSize</dt>
+
+      <dd>The size of the data in bytes before any compression or other
+      encoding.</dd>
+    </dl>
+
+    <p>The value of the <span class="term">compressedSize</span> field
+    MUST be equal to the product of the length of the scalar array field
+    stored in the <span class="term">value</span> field and the size of
+    the scalar type in bytes (i.e. 1, 2, 4 or 8 for signed or unsigned
+    byte, short, int or long respectively, 1 for boolean, 4 for float and
+    8 for double).</p>
+
+    <p>The value of the <span class="term">uncompressedSize</span> field
+    MUST be equal to the product of the value of the <span class=
+    "term">size</span> field of each element in the structure array
+    <span class="term">dimension</span> field (described below) and the
+    size in bytes of the scalar type of the scalar array represented by
+    <span class="term">value</span>. If the number of elements of the
+    <span class="term">dimension</span> field is 0 the value of the
+    <span class="term">uncompressedSize</span> MUST be 0.</p>
+
+    <h4>Dimensions</h4>
+
+    <p>The <span class="nterm">Dimensions</span> part of an NTNDArray is
+    composed of the <span class="term">dimension</span> field</p>
+    <pre>
+    <span class="nterm">dimension_t[]</span> dimension
 </pre>
-<p>A <span class="nterm">dimension_t</span> 
-  is implemented as a pvData Field of type <a
-   href="http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure"
-   >"structure"</a> of type ID  "dimension_t" with the following form:</p>
-<pre>
+
+    <p>A <span class="nterm">dimension_t</span> is implemented as a pvData
+    Field of type <a href=
+    "http://epics-pvdata.sourceforge.net/docbuild/pvDataJava/tip/documentation/pvDataJava.html#metalang_structure">
+    "structure"</a> of type ID "dimension_t" with the following form:</p>
+    <pre>
 <span class="nterm">dimension_t</span> :=
 
 structure
@@ -1905,73 +2210,91 @@ structure
     int     binning
     boolean reverse
 </pre>
-<p>where:</p>
-<dl>
-  <dt>size</dt>
-    <dd>The number of elements in this dimension of the array.</dd>
-  <dt>offset</dt>
-    <dd>The offset in this dimension relative to the origin of the original data
-source.</dd>
-  <dt>fullSize</dt>
-    <dd>The number of elements in this dimension of the the original data
-source.</dd>
-  <dt>binning</dt>
-    <dd>The binning (pixel summation, 1=no binning) in this dimension relative to original data source
-      source.</dd>
-  <dt>reverse</dt>
-    <dd>The orientation (false=normal, true=reversed) in this dimension relative to the original data source
-      source.</dd>
-</dl>
 
-<p>
-The number of elements in the value of the <span class="term">dimension</span> field MAY be 0. A
-client SHOULD check for this case and take appropriate action.
-</p>
-<p>
-If an NTNDArray represents a subregion of a larger region of interest of an original image,
-its <span class="term">offset</span>, <span class="term">binning</span>
-and <span class="term">reverse</span>field values SHOULD be relative to the original image
-and its <span class="term">fullSize</span> field value SHOULD be the size of the original.
-</p>
-<span class="nterm">dimension_t</span> is analogous to <a
- href="http://cars9.uchicago.edu/software/epics/areaDetectorDoxygenHTML/struct_n_d_dimension.html">NDDimension_t</a>  in areaDetector.
+    <p>where:</p>
 
-<h4>Unique ID and data timestamp</h4>
+    <dl>
+      <dt>size</dt>
 
-<p>The <span class="nterm">Unique ID and data timestamp</span> parts of an NTNDArray are composed of the
-following fields:</p>
-<pre>    int     uniqueId
+      <dd>The number of elements in this dimension of the array.</dd>
+
+      <dt>offset</dt>
+
+      <dd>The offset in this dimension relative to the origin of the
+      original data source.</dd>
+
+      <dt>fullSize</dt>
+
+      <dd>The number of elements in this dimension of the the original
+      data source.</dd>
+
+      <dt>binning</dt>
+
+      <dd>The binning (pixel summation, 1=no binning) in this dimension
+      relative to original data source source.</dd>
+
+      <dt>reverse</dt>
+
+      <dd>The orientation (false=normal, true=reversed) in this dimension
+      relative to the original data source source.</dd>
+    </dl>
+
+    <p>The number of elements in the value of the <span class=
+    "term">dimension</span> field MAY be 0. A client SHOULD check for this
+    case and take appropriate action.</p>
+
+    <p>If an NTNDArray represents a subregion of a larger region of
+    interest of an original image, its <span class="term">offset</span>,
+    <span class="term">binning</span> and <span class=
+    "term">reverse</span>field values SHOULD be relative to the original
+    image and its <span class="term">fullSize</span> field value SHOULD be
+    the size of the original.</p><span class="nterm">dimension_t</span> is
+    analogous to <a href=
+    "http://cars9.uchicago.edu/software/epics/areaDetectorDoxygenHTML/struct_n_d_dimension.html">
+    NDDimension_t</a> in areaDetector.
+
+    <h4>Unique ID and data timestamp</h4>
+
+    <p>The <span class="nterm">Unique ID and data timestamp</span> parts
+    of an NTNDArray are composed of the following fields:</p>
+    <pre>
+    int     uniqueId
     time_t  dataTimeStamp
 </pre>
 
-<p>where:</p>
-<dl>
-  <dt>uniqueId</dt>
-    <dd>A number that SHOULD be unique for all NTNDArrays produced by a source
-      after it has started.</dd>
-  <dt>dataTimeStamp</dt>
-    <dd>Timestamp of the data.</dd>
-</dl>
-<p>
-The value of <span class="term">dataTimeStamp</span> MAY be different from that of the (optional) <span class="term">timeStamp</span> field below.
-</p>
-<p>
-The <span class="term">uniqueId</span> and <span class="term">dataTimeStamp</span> fields of
-NTNDArray correspond to the uniqueId and timeStamp fields respectively of an NDArray.
-</p>
-<h4>NTNDArray attributes</h4>
-<p>
+    <p>where:</p>
 
+    <dl>
+      <dt>uniqueId</dt>
 
-The <span class="nterm">Attributes</span> part of an NTNDArray is composed of the
-field:</p>
+      <dd>A number that SHOULD be unique for all NTNDArrays produced by a
+      source after it has started.</dd>
 
-<pre>    <span class="nterm">NTAttribute[]</span> attribute
+      <dt>dataTimeStamp</dt>
+
+      <dd>Timestamp of the data.</dd>
+    </dl>
+
+    <p>The value of <span class="term">dataTimeStamp</span> MAY be
+    different from that of the (optional) <span class=
+    "term">timeStamp</span> field below.</p>
+
+    <p>The <span class="term">uniqueId</span> and <span class=
+    "term">dataTimeStamp</span> fields of NTNDArray correspond to the
+    uniqueId and timeStamp fields respectively of an NDArray.</p>
+
+    <h4>NTNDArray attributes</h4>
+
+    <p>The <span class="nterm">Attributes</span> part of an NTNDArray is
+    composed of the field:</p>
+    <pre>
+    <span class="nterm">NTAttribute[]</span> attribute
 </pre>
 
-<p>where <span class="nterm">NTAttribute</span> is as defined by this standard, but is extended in this case as follows:</p>
-
-<pre><span class="nterm">NTAttribute</span> :=
+    <p>where <span class="nterm">NTAttribute</span> is as defined by this
+    standard, but is extended in this case as follows:</p>
+    <pre>
+<span class="nterm">NTAttribute</span> :=
 
 structure
     string    name              
@@ -1984,65 +2307,83 @@ structure
     string    source
 </pre>
 
-<p>where:</p>
-<dl>
-  <dt>sourceType</dt>
-    <dd>The origin of the attribute
-      <pre>NDAttrSourceDriver   = 0,   /** Attribute is obtained directly from driver */
+    <p>where:</p>
+
+    <dl>
+      <dt>sourceType</dt>
+
+      <dd>
+        The origin of the attribute
+        <pre>
+NDAttrSourceDriver   = 0,   /** Attribute is obtained directly from driver */
 NDAttrSourceParam    = 1,   /** Attribute is obtained from an asyn parameter library */
 NDAttrSourceEPICSPV  = 2,   /** Attribute is obtained from an EPICS PV */
-NDAttrSourceFunct    = 3    /** Attribute is obtained from a user-specified function  */</pre>
-    </dd>
-  <dt>source</dt>
-    <dd>The source string of this attribute.</dd>
-</dl>
+NDAttrSourceFunct    = 3    /** Attribute is obtained from a user-specified function  */
+</pre>
+      </dd>
 
-<p>Note that the optional descriptor field of <span class="nterm">NTAttribute</span> is mandatory for attributes of an NTNDArray.</p>
+      <dt>source</dt>
 
-<p><span class="nterm">NTAttribute</span> here is extended by the addition of the <span class="term">sourceType</span>
-and <span class="term">source</span> fields.
-<span class="term">source</span> is a string which gives the origin of the attribute according
-to the value of the integer <span class="term">sourceType</span> field as follows:</p>
-<ul>
-<li>For a <span class="term">sourceType</span> of value <span class="term">NDAttrSourceDriver</span>
-the <span class="term">source</span> string SHOULD be the empty string.</li>
-<li>For a <span class="term">sourceType</span> of value <span class="term">NDAttrSourceParam</span>
-the <span class="term">source</span> string SHOULD be the name of the <a
- href="http://www.aps.anl.gov/epics/modules/soft/asyn/">asyn</a> parameter from which the attribute
- value was obtained.</li>
-<li> For a <span class="term">sourceType</span> of value <span class="term">NDAttrSourceEPICSPV</span>
-the <span class="term">source</span> string SHOULD be the name of the EPICS PV from which the attribute
- value was obtained.</li>
-<li> For a <span class="term">sourceType</span> of value <span class="term">NDAttrSourceFunct</span>
-the <span class="term">source</span> string SHOULD be the name of the user function from which the
-attribute value was obtained.</li>
-</ul>
+      <dd>The source string of this attribute.</dd>
+    </dl>
 
+    <p>Note that the optional descriptor field of <span class=
+    "nterm">NTAttribute</span> is mandatory for attributes of an
+    NTNDArray.</p>
 
-<p>The extension of <span class="nterm">NTAttribute</span> is analogous to <a
- href="http://cars9.uchicago.edu/software/epics/areaDetectorDoxygenHTML/class_n_d_attribute.html">NDAttribute</a>
- in areaDetector. The <span class="term">name</span>, <span class="term">descriptor</span>,
- <span class="term">sourceType</span> and <span class="term">source</span> fields correspond
- to the pName, pDescription, sourceType, pSource members of an NDAttribute respectively.
-</p>
+    <p><span class="nterm">NTAttribute</span> here is extended by the
+    addition of the <span class="term">sourceType</span> and <span class=
+    "term">source</span> fields. <span class="term">source</span> is a
+    string which gives the origin of the attribute according to the value
+    of the integer <span class="term">sourceType</span> field as
+    follows:</p>
 
-<p>
-The attributes themselves are not defined by this standard.
-</p>
+    <ul>
+      <li>For a <span class="term">sourceType</span> of value <span class=
+      "term">NDAttrSourceDriver</span> the <span class=
+      "term">source</span> string SHOULD be the empty string.</li>
 
-<p>For areaDetector applications the <span class="term">attribute</span> field encodes the
-linked list of NDAttributes in an NDArray. 
-</p>
+      <li>For a <span class="term">sourceType</span> of value <span class=
+      "term">NDAttrSourceParam</span> the <span class="term">source</span>
+      string SHOULD be the name of the <a href=
+      "http://www.aps.anl.gov/epics/modules/soft/asyn/">asyn</a> parameter
+      from which the attribute value was obtained.</li>
 
+      <li>For a <span class="term">sourceType</span> of value <span class=
+      "term">NDAttrSourceEPICSPV</span> the <span class=
+      "term">source</span> string SHOULD be the name of the EPICS PV from
+      which the attribute value was obtained.</li>
 
+      <li>For a <span class="term">sourceType</span> of value <span class=
+      "term">NDAttrSourceFunct</span> the <span class="term">source</span>
+      string SHOULD be the name of the user function from which the
+      attribute value was obtained.</li>
+    </ul>
 
-[Note: areaDetector currently defines two integer attributes, colorMode and bayerPattern,
-with descriptions "Color mode" and "Bayer pattern" respectively:
-<dl>
-  <dt>colorMode</dt>
-    <dd>An attribute that describes how an N-d array is to be interpreted as an image, taking
-    one of the values in this enumeration: 
-      <pre>
+    <p>The extension of <span class="nterm">NTAttribute</span> is
+    analogous to <a href=
+    "http://cars9.uchicago.edu/software/epics/areaDetectorDoxygenHTML/class_n_d_attribute.html">
+    NDAttribute</a> in areaDetector. The <span class="term">name</span>,
+    <span class="term">descriptor</span>, <span class=
+    "term">sourceType</span> and <span class="term">source</span> fields
+    correspond to the pName, pDescription, sourceType, pSource members of
+    an NDAttribute respectively.</p>
+
+    <p>The attributes themselves are not defined by this standard.</p>
+
+    <p>For areaDetector applications the <span class=
+    "term">attribute</span> field encodes the linked list of NDAttributes
+    in an NDArray.</p>[Note: areaDetector currently defines two integer
+    attributes, colorMode and bayerPattern, with descriptions "Color mode"
+    and "Bayer pattern" respectively:
+
+    <dl>
+      <dt>colorMode</dt>
+
+      <dd>
+        An attribute that describes how an N-d array is to be interpreted
+        as an image, taking one of the values in this enumeration:
+        <pre>
 NDColorModeMono   = 0,    /** Monochromatic image */
 NDColorModeBayer  = 1,    /** Bayer pattern image,
                               1 value per pixel but with color filter on detector */
@@ -2054,31 +2395,39 @@ NDColorModeRGB3   = 4,    /** RGB image with plane color interleave,
                               data array is [NX, NY, 3]  */
 NDColorModeYUV444 = 5,    /** YUV image, 3 bytes encodes 1 RGB pixel */
 NDColorModeYUV422 = 6,    /** YUV image, 4 bytes encodes 2 RGB pixel */
-NDColorModeYUV411 = 7     /** YUV image, 6 bytes encodes 4 RGB pixels */</pre>
-    </dd>
-  <dt>bayerPattern</dt>
-    <dd>An attribute valid when colorMode is NDColorModeBayer providing additional information required for the interpretation of an N-d array as an image in this case, taking one of the values in this enumeration:
-      <pre>NDBayerRGGB       = 0,    /** First line RGRG, second line GBGB... */
+NDColorModeYUV411 = 7     /** YUV image, 6 bytes encodes 4 RGB pixels */
+</pre>
+      </dd>
+
+      <dt>bayerPattern</dt>
+
+      <dd>
+        An attribute valid when colorMode is NDColorModeBayer providing
+        additional information required for the interpretation of an N-d
+        array as an image in this case, taking one of the values in this
+        enumeration:
+        <pre>
+NDBayerRGGB       = 0,    /** First line RGRG, second line GBGB... */
 NDBayerGBRG       = 1,    /** First line GBGB, second line RGRG... */
 NDBayerGRBG       = 2,    /** First line GRGR, second line BGBG... */
-NDBayerBGGR       = 3     /** First line BGBG, second line GRGR... */</pre>
-    </dd>
-</dl>
-Other areaDetector attributes are user-defined.]
+NDBayerBGGR       = 3     /** First line BGBG, second line GRGR... */
+</pre>
+      </dd>
+    </dl>Other areaDetector attributes are user-defined.]
 
-<h3>NTContinuum</h3>
+    <h3>NTContinuum</h3>
 
-<p>NTContinuum is the  EPICS V4 Normative Type used to express a sequence of point
-  values in time or frequency domain.  Each point has N values (N>=1) 
-and an additional value which describes the index of the list.  The 
-additional value is carried in the <span class="term">base</span>
- field.  The <span class="term">value</span> field 
-carries the values which make up the point in index order.</p>
-<p>
-An additional <span class="term">units</span> field gives a units string
-for the N values and the additional value.
-</p>
-<pre><span class="nterm">NTContinuum</span> := 
+    <p>NTContinuum is the EPICS V4 Normative Type used to express a
+    sequence of point values in time or frequency domain. Each point has N
+    values (N&gt;=1) and an additional value which describes the index of
+    the list. The additional value is carried in the <span class=
+    "term">base</span> field. The <span class="term">value</span> field
+    carries the values which make up the point in index order.</p>
+
+    <p>An additional <span class="term">units</span> field gives a units
+    string for the N values and the additional value.</p>
+    <pre>
+<span class="nterm">NTContinuum</span> := 
 
 structure
     double[]   base
@@ -2088,30 +2437,28 @@ structure
     <span class="nterm">alarm_t</span>    alarm         :opt
     <span class="nterm">time_t</span>     timeStamp     :opt</span>
 </pre>
-<p>
-The number of values in a point must be derived as:</p>
-<dfn>
-Nvals = len(value)/len(base)</dfn>
-<p>
-And the following invariant must be preserved:</p>
-<dfn>
-len(units)-1 == Nvals</dfn>
-<p>
-The order of the point (A, B, C) for indices 1, 2, 3 the order of the 
-<span class="term">value</span> array is:</p>
-<samp>
-[A1, B1, C1, A2, B2, C2, A3, B3, C3] </samp>
 
-<h3>NTHistogram</h3>
+    <p>The number of values in a point must be derived as:</p><dfn>Nvals =
+    len(value)/len(base)</dfn>
 
-<p>NTHistogram is the EPICS V4 Normative Type used to encode the data and
-representation of a (1 dimensional) histogram. Specifically, it encapsulates frequency
-binned data.</p>
-<p>For 2d histograms (i.e. both x and y observations are binned) and n-tuple
-data (e.g. land masses of different listed countries) see NTMatrix or NTTable.
-</p>
+    <p>And the following invariant must be preserved:</p><dfn>len(units)-1
+    == Nvals</dfn>
 
-<pre><span class="nterm">NTHistogram</span> := 
+    <p>The order of the point (A, B, C) for indices 1, 2, 3 the order of
+    the <span class="term">value</span> array is:</p><samp>[A1, B1, C1,
+    A2, B2, C2, A3, B3, C3]</samp>
+
+    <h3>NTHistogram</h3>
+
+    <p>NTHistogram is the EPICS V4 Normative Type used to encode the data
+    and representation of a (1 dimensional) histogram. Specifically, it
+    encapsulates frequency binned data.</p>
+
+    <p>For 2d histograms (i.e. both x and y observations are binned) and
+    n-tuple data (e.g. land masses of different listed countries) see
+    NTMatrix or NTTable.</p>
+    <pre>
+<span class="nterm">NTHistogram</span> := 
 
 structure
     double[]   ranges                     // The start and end points of each bin 
@@ -2121,51 +2468,52 @@ structure
     <span class="nterm">time_t</span>     timeStamp     :opt</span>
 </pre>
 
-<h4>Interpretation</h4>
+    <h4>Interpretation</h4>
 
-<p>One NTHistogram gives the information required to convey a histogram
-representation of some underlying observations. It does not convey the values of each
-of the observations themselves.</p>
+    <p>One NTHistogram gives the information required to convey a
+    histogram representation of some underlying observations. It does not
+    convey the values of each of the observations themselves.</p>
 
-<p>The number of bins is given by the length of the  <span class="term">value</span> array.
- <span class="term">ranges</span> indicates the low value and high value of each bin. The range for
-<i>bin(i)</i> is given by <i>ranges(i)</i> to <i>ranges(i+1)</i>. Specifically, since
-we want end points of both the first bin and last bin included, all bin intervals
-except the last one, MUST be <i>right half
-open</i>; from that bin's low value <i>ranges(i)</i> (included) to that bin's high
-value <i>ranges(i+1)</i> (excluded). The last bin MUST be fully <i>open</i> (low and
-high value included).</p>
+    <p>The number of bins is given by the length of the <span class=
+    "term">value</span> array. <span class="term">ranges</span> indicates
+    the low value and high value of each bin. The range for <i>bin(i)</i>
+    is given by <i>ranges(i)</i> to <i>ranges(i+1)</i>. Specifically,
+    since we want end points of both the first bin and last bin included,
+    all bin intervals except the last one, MUST be <i>right half open</i>;
+    from that bin's low value <i>ranges(i)</i> (included) to that bin's
+    high value <i>ranges(i+1)</i> (excluded). The last bin MUST be fully
+    <i>open</i> (low and high value included).</p>
 
-<p>A log plot histogram (in which the independent variable x is binned on a log
-scale), would be communicated using a range array of decades (1.0E01,
-1.0E02, 1.0E03 etc).
-</p>
+    <p>A log plot histogram (in which the independent variable x is binned
+    on a log scale), would be communicated using a range array of decades
+    (1.0E01, 1.0E02, 1.0E03 etc).</p>
 
-<h4>Validation</h4>
-<p>The array length of <span class="term">ranges</span> MUST be the array length
-of <span class="term">value</span> + 1. </p>
+    <h4>Validation</h4>
 
+    <p>The array length of <span class="term">ranges</span> MUST be the
+    array length of <span class="term">value</span> + 1.</p>
 
-<h3>NTAggregate</h3>
+    <h3>NTAggregate</h3>
 
-<p>NTAggregate is the EPICS V4 Normative Type to compactly convey data which
-combines several measurements or observation. NTAggregate gives simple
-summary statistic <a class="bib" href="#bib:agg">bib:agg</a> about the central
-tendency and dispersion of a set of data points.</p>
+    <p>NTAggregate is the EPICS V4 Normative Type to compactly convey data
+    which combines several measurements or observation. NTAggregate gives
+    simple summary statistic <a class="bib" href="#bib:agg">bib:agg</a>
+    about the central tendency and dispersion of a set of data points.</p>
 
-<p>Use cases: for instance, an NTAggregate could be used to summarize the value of one
-beam position offset reading over some number of pulses (N). It also includes the
-time range of the sampled points, so it could be used for time domain rebasing. For
-instance, an FPGA sending data at 10KHz, and you want to display its output,
-but you don't want to display at the native rate.  Also, it could be used for
-transmitting or storing compressed archive data.</p>
+    <p>Use cases: for instance, an NTAggregate could be used to summarize
+    the value of one beam position offset reading over some number of
+    pulses (N). It also includes the time range of the sampled points, so
+    it could be used for time domain rebasing. For instance, an FPGA
+    sending data at 10KHz, and you want to display its output, but you
+    don't want to display at the native rate. Also, it could be used for
+    transmitting or storing compressed archive data.</p>
 
-<p>NTAggregate doesn't cover the shape of a distribution so it only reasonably helps
-you do symmetrical distributions (no skewness or kurtosis), and it doesn't include
-any help for indicating the extent of dependency on another variable
-(correlation). </p>
-
-<pre><span class="nterm">NTAggregate</span> := 
+    <p>NTAggregate doesn't cover the shape of a distribution so it only
+    reasonably helps you do symmetrical distributions (no skewness or
+    kurtosis), and it doesn't include any help for indicating the extent
+    of dependency on another variable (correlation).</p>
+    <pre>
+<span class="nterm">NTAggregate</span> := 
 
 structure
     double     value                 // The center point of the observations,
@@ -2174,9 +2522,11 @@ structure
     double     dispersion      :opt  // Dispersion of observations;
                                       // nominally the Standard Deviation or RMS
     double     first           :opt  // Initial observation value 
-    <span class="nterm">time_t</span>     firstTimeStamp  :opt  // Time of initial observation
+    <span class=
+"nterm">time_t</span>     firstTimeStamp  :opt  // Time of initial observation
     double     last            :opt  // Final observation value
-    <span class="nterm">time_t</span>     lastTimeStamp   :opt  // Time of final observation
+    <span class=
+"nterm">time_t</span>     lastTimeStamp   :opt  // Time of final observation
     double     max             :opt  // Highest value in the N observations
     double     min             :opt  // Lowest value in the N observations<span class="opt">
     string     descriptor      :opt  
@@ -2184,61 +2534,86 @@ structure
     <span class="nterm">time_t</span>     timeStamp       :opt</span>
 </pre>
 
-<p>where:</p>
-<dl>
-  <dt>value</dt>
-   <dd>The summary statistic of the set of observations conveyed by this
-     NTAggregate. For instance their arithmetic mean.</dd>
-  <dt>N</dt>
-   <dd>The number of observations summarized by this NTAggregate.</dd>
-  <dt>dispersion</dt>
-   <dd>The extent to which the observations are centered around the <span
-     class="term">value</span>. For instance, if the
-     <span class="term">value</span> contains a mean, then the dispersion may be the
-     variance or the standard deviation. The <span class="term">descriptor</span>
-     should indicate which.</dd>
-  <dt>first</dt>
-  <dd>The value of the temporally first observation conveyed by this NTAggregate.</dd>
-  <dt>firstTimeStamp</dt>
-    <dd>The time of observation of the temporally first observation conveyed by this NTAggregate.</dd>
-  <dt>last</dt>
-  <dd>The value of the temporally final observation conveyed by this NTAggregate.</dd>
-  <dt>lastTimeStamp</dt>
-   <dd>The time of observation of the temporally final observation conveyed by this NTAggregate.</dd>
-  <dt>max</dt>
-    <dd>The numerically largest value in the set of observations conveyed by this NTAggregate.</dd>
-  <dt>min</dt>
-    <dd>The numerically smallest value in the set of observations conveyed by this NTAggregate.</dd>
-</dl>
+    <p>where:</p>
 
-<h4>Interpretation</h4>
-<p>
-One NTAggregate instance describes some number (given by N) of observations. If
-firstTimeStamp and lastTimeStamp are given, then the N observations MUST have been taken
-over the period of time specified. If first, last, max or min are given, they MUST refer
-to the actual values of the N observations being summarized.  
-</p>
+    <dl>
+      <dt>value</dt>
 
-<p>The <span class="term">value</span> field value computed by server agents may be
-the arithmetic mean of the observation data being summarized by this NTAggregate, but
-NTAggregate does not normatively define that. Other measures of mean (geometric,
-harmonic) may be assigned. Indeed other measures of central tendency may be used. The
-interpretation to give an instance of an NTAggregate SHOULD be conveyed in the <span
-class="term">descriptor</span>. </p>
+      <dd>The summary statistic of the set of observations conveyed by
+      this NTAggregate. For instance their arithmetic mean.</dd>
 
-<p>Where dispersion is a measure of the standard deviation, which estimator of the
-standard deviation [1/N or 1/(N-1)] was used, is also not defined normatively.</p>
+      <dt>N</dt>
 
+      <dd>The number of observations summarized by this NTAggregate.</dd>
 
-<h2>Appendix A: Possible Future Additions to this Specification</h2>
+      <dt>dispersion</dt>
 
+      <dd>The extent to which the observations are centered around the
+      <span class="term">value</span>. For instance, if the <span class=
+      "term">value</span> contains a mean, then the dispersion may be the
+      variance or the standard deviation. The <span class=
+      "term">descriptor</span> should indicate which.</dd>
 
-<h3>NTUnion</h3>
+      <dt>first</dt>
 
-<p><span class="nterm">NTUnion</span> would be a Normative Type for interoperation of
-essentially any data structure, plus description, alarm and timestamp fields.</p>
+      <dd>The value of the temporally first observation conveyed by this
+      NTAggregate.</dd>
 
-<pre><span class="nterm">NTUnion</span> := 
+      <dt>firstTimeStamp</dt>
+
+      <dd>The time of observation of the temporally first observation
+      conveyed by this NTAggregate.</dd>
+
+      <dt>last</dt>
+
+      <dd>The value of the temporally final observation conveyed by this
+      NTAggregate.</dd>
+
+      <dt>lastTimeStamp</dt>
+
+      <dd>The time of observation of the temporally final observation
+      conveyed by this NTAggregate.</dd>
+
+      <dt>max</dt>
+
+      <dd>The numerically largest value in the set of observations
+      conveyed by this NTAggregate.</dd>
+
+      <dt>min</dt>
+
+      <dd>The numerically smallest value in the set of observations
+      conveyed by this NTAggregate.</dd>
+    </dl>
+
+    <h4>Interpretation</h4>
+
+    <p>One NTAggregate instance describes some number (given by N) of
+    observations. If firstTimeStamp and lastTimeStamp are given, then the
+    N observations MUST have been taken over the period of time specified.
+    If first, last, max or min are given, they MUST refer to the actual
+    values of the N observations being summarized.</p>
+
+    <p>The <span class="term">value</span> field value computed by server
+    agents may be the arithmetic mean of the observation data being
+    summarized by this NTAggregate, but NTAggregate does not normatively
+    define that. Other measures of mean (geometric, harmonic) may be
+    assigned. Indeed other measures of central tendency may be used. The
+    interpretation to give an instance of an NTAggregate SHOULD be
+    conveyed in the <span class="term">descriptor</span>.</p>
+
+    <p>Where dispersion is a measure of the standard deviation, which
+    estimator of the standard deviation [1/N or 1/(N-1)] was used, is also
+    not defined normatively.</p>
+
+    <h2>Appendix A: Possible Future Additions to this Specification</h2>
+
+    <h3>NTUnion</h3>
+
+    <p><span class="nterm">NTUnion</span> would be a Normative Type for
+    interoperation of essentially any data structure, plus description,
+    alarm and timestamp fields.</p>
+    <pre>
+<span class="nterm">NTUnion</span> := 
 
 structure
     <span class="nterm">anyunion_t</span>   value<span class="opt">
@@ -2247,20 +2622,23 @@ structure
     <span class="nterm">time_t</span>       timeStamp        :opt</span>
 </pre>
 
-<h3>NTScalarMultiChannel</h3>
+    <h3>NTScalarMultiChannel</h3>
 
-<p>NTScalarMultiChannel is an EPICS V4 Normative Type that aggregates an array of 
-values from different EPICS Process Variable (PV) channel sources of the same scalar type into a single variable. </p>
+    <p>NTScalarMultiChannel is an EPICS V4 Normative Type that aggregates
+    an array of values from different EPICS Process Variable (PV) channel
+    sources of the same scalar type into a single variable.</p>
 
-<p>Use cases: In a particle accelerator, a single NTScalarMultiChannel might
- include the data of a number of Beam Position Monitors' X offset values,
-or of a number of quadrupoles' desired field values. </p>
-
-<pre><span class="nterm">NTScalarMultiChannel</span> := 
+    <p>Use cases: In a particle accelerator, a single NTScalarMultiChannel
+    might include the data of a number of Beam Position Monitors' X offset
+    values, or of a number of quadrupoles' desired field values.</p>
+    <pre>
+<span class="nterm">NTScalarMultiChannel</span> := 
 
 structure 
-    <span class="nterm">scalar_t[]  </span>  value              // The channel values
-    string[]      channelName        // The channel names    <span class="opt">
+    <span class=
+"nterm">scalar_t[]  </span>  value              // The channel values
+    string[]      channelName        // The channel names    <span class=
+"opt">
     string        descriptor         :opt
     <span class="nterm">alarm_t</span>       alarm              :opt
     <span class="nterm">time_t</span>        timeStamp          :opt
@@ -2269,194 +2647,304 @@ structure
     string[]      message            :opt
     long[]        secondsPastEpoch   :opt
     int[]         nanoseconds        :opt
-    int[]         userTag            :opt</span></pre>
+    int[]         userTag            :opt</span>
+</pre>
 
-<p>where:</p>
-<dl>
-  <dt>value</dt>
-    <dd>The value from each channel.</dd>
-  <dt>channelName</dt>
-      <dd>The name of each channel.
-	</dd>
-  <dt>alarm</dt>
-     <dd>The alarm associated with the NTScalarMultiChannel itself.
-      <span class="term">severity</span>, <span class="term">status</span>, and <span class="term">message</span> show the alarm for each channel.
-      </dd>
-  <dt>timeStamp</dt>
-     <dd>The timestamp associated with the NTScalarMultiChannel itself.
-      <span class="term">secondsPastEpoch</span>, <span class="term">nanoseconds</span> and <span class="term">userTag</span> show the timestamp for each channel.
-      </dd>
-  <dt>severity</dt>
-    <dd>The alarm severity associated with each channel.</dd>
-  <dt>status</dt>
-    <dd>The alarm status associated with each channel.</dd>
-  <dt>message</dt>
-    <dd>The alarm message associated with each channel.</dd>
-  <dt>secondsPastEpoch</dt>
-    <dd>The <span class="term">secondsPastEpoch</span> field of the timestamp associated with each channel.</dd>
-  <dt>nanoseconds</dt>
-    <dd>The <span class="term">nanoseconds</span> field of the timestamp associated with each channel.</dd>
-  <dt>userTag</dt>
-    <dd>The <span class="term">userTag</span> field of the timestamp associated with each channel.</dd>
-</dl>
+    <p>where:</p>
 
-<a id="normative_ntype_list"></a>
-<h2>Appendix B: Normative Type Identifiers</h2>
+    <dl>
+      <dt>value</dt>
 
-<p>This Appendix describes the Normative Type Identifiers of the abstract
-data types defined by this document. These are the strings which identify the
-type carried by a structure. In the pvAccess binding (which is at
-present the only one implemented for EPICS V4), the type ID
-of the structure MUST carry one of these identifier strings.
-In doing so, the structure instance declares itself to conform to
-the corresponding definition carried in this specification document. 
-</p>
+      <dd>The value from each channel.</dd>
 
-<p>The syntax of the Normative Type identifier is:</p>
-<pre>
+      <dt>channelName</dt>
+
+      <dd>The name of each channel.</dd>
+
+      <dt>alarm</dt>
+
+      <dd>The alarm associated with the NTScalarMultiChannel itself.
+      <span class="term">severity</span>, <span class=
+      "term">status</span>, and <span class="term">message</span> show the
+      alarm for each channel.</dd>
+
+      <dt>timeStamp</dt>
+
+      <dd>The timestamp associated with the NTScalarMultiChannel itself.
+      <span class="term">secondsPastEpoch</span>, <span class=
+      "term">nanoseconds</span> and <span class="term">userTag</span> show
+      the timestamp for each channel.</dd>
+
+      <dt>severity</dt>
+
+      <dd>The alarm severity associated with each channel.</dd>
+
+      <dt>status</dt>
+
+      <dd>The alarm status associated with each channel.</dd>
+
+      <dt>message</dt>
+
+      <dd>The alarm message associated with each channel.</dd>
+
+      <dt>secondsPastEpoch</dt>
+
+      <dd>The <span class="term">secondsPastEpoch</span> field of the
+      timestamp associated with each channel.</dd>
+
+      <dt>nanoseconds</dt>
+
+      <dd>The <span class="term">nanoseconds</span> field of the timestamp
+      associated with each channel.</dd>
+
+      <dt>userTag</dt>
+
+      <dd>The <span class="term">userTag</span> field of the timestamp
+      associated with each channel.</dd>
+    </dl><a id="normative_ntype_list" name="normative_ntype_list"></a>
+
+    <h2>Appendix B: Normative Type Identifiers</h2>
+
+    <p>This Appendix describes the Normative Type Identifiers of the
+    abstract data types defined by this document. These are the strings
+    which identify the type carried by a structure. In the pvAccess
+    binding (which is at present the only one implemented for EPICS V4),
+    the type ID of the structure MUST carry one of these identifier
+    strings. In doing so, the structure instance declares itself to
+    conform to the corresponding definition carried in this specification
+    document.</p>
+
+    <p>The syntax of the Normative Type identifier is:</p>
+    <pre>
     <i>namespacename</i>/<i>typename</i>:<i>versionnumber</i>
 </pre>
-<p>The Normative Type Identifier "Namespace Name" part, is:</p>
 
-<pre id="ntnamespacename_pwd">
+    <p>The Normative Type Identifier "Namespace Name" part, is:</p>
+    <pre id="ntnamespacename_pwd">
     epics:nt
 </pre>
 
-<p>The Normative Type Identifier "Type Name" and version number parts corresponding
-to <a href="#thisversion" >this draft</a> of the Normative Types Document (this document),
-MUST be valued as following:</p>
+    <p>The Normative Type Identifier "Type Name" and version number parts
+    corresponding to <a href="#thisversion">this draft</a> of the
+    Normative Types Document (this document), MUST be valued as
+    following:</p>
 
-<table>
-  <caption>Type Names that may be used in the Type Name part of a Normative Type
-  Identifier of an EPICS V4 Normative Type in the namespace of this draft
-  of the Normative Types specification</caption> 
-  <tr>
-    <th>Type Name</th>
-    <th>Version</th>
-    <th>Depends on</th>
-    <th>Short Description</th>
-  </tr>
-  <tr>
-    <td>NTScalar</td>
-    <td>1.0</td>
-    <td>(none)</td>
-    <td>A single scalar value.</td>
-  </tr>
-  <tr>
-    <td>NTScalarArray</td>
-    <td>1.0</td>
-    <td>(none)</td>
-    <td>An array of scalar values of some single type.</td>
-  </tr>
-  <tr>
-    <td>NTEnum</td>
-    <td>1.0</td>
-    <td>(none)</td>
-    <td>An enumeration list and a value of that enumeration.</td>
-  </tr>
-  <tr>
-    <td>NTMatrix</td>
-    <td>1.0</td>
-    <td>(none)</td>
-    <td>A real number matrix.</td>
-  </tr>
-  <tr>
-    <td>NTURI</td>
-    <td>1.0</td>
-    <td>(none)</td>
-    <td>A structure for encapsulating a Uniform Resource Identifier (URI).</td>
-  </tr>
-  <tr>
-    <td>NTNameValue</td>
-    <td>1.0</td>
-    <td>(none)</td>
-    <td>An array of scalar values where each element is named.</td>
-  </tr>
-  <tr>
-    <td>NTTable</td>
-    <td>1.0</td>
-    <td>(none)</td>
-    <td>A table of scalars, where each column may be of different scalar array type</td>
-  </tr>
-  <tr>
-    <td>NTAttribute</td>
-    <td>1.0</td>
-    <td>(none)</td>
-    <td>A key-value pair, with optional string tags, where the value is of any type.</td>
-  </tr>
-  <tr>
-    <td>NTMultiChannel</td>
-    <td>1.0</td>
-    <td>(none)</td>
-    <td>An array of PV names, their values, and metadata.</td>
-  </tr>
-  <tr>
-    <td>NTNDArray</td>
-    <td>1.0</td>
-    <td>NTAttribute 1.0</td>
-    <td>A pixel and metadata type, designed to encode a frame of data from detectors and cameras.</td>
-  </tr>
-  <tr>
-    <td>NTContinuum</td>
-    <td>1.0</td>
-    <td>(none)</td>
-    <td>Expresses a sequence of data points in time or frequency domain.</td>
-  </tr>
-  <tr>
-    <td>NTHistogram</td>
-    <td>1.0</td>
-    <td>(none)</td>
-    <td>An array of real number intervals, and their frequency counts. Expresses a
-    1D histogram.</td>
-  </tr>
-  <tr>
-    <td>NTAggregate</td>
-    <td>1.0</td>
-    <td>(none)</td>
-    <td>A mean value, standard deviation, and other metadata. Expresses the central
-        tendency and dispersion of a set of data points.</td>
-  </tr>
-</table>
-<p>For example, the type ID of a structure describing an NTScalar, must be valued
-"epics:nt/NTScalar:1.0". The type ID of a structure describing an NTNDArray, must be valued
-"epics:nt/NTNDArray:1.0".</p>
-<p>Following drafts of this document MAY well correspond to the same Namespace Name
-and Type Names as used in this draft. Also note that the same namespace may well be
-used for a different collection of types or Type Names, as this document matures.</p>
+    <table summary="Normative Type definition versions and their inter-dependencies">
+      <caption>
+        Type Names that may be used in the Type Name part of a Normative
+        Type Identifier of an EPICS V4 Normative Type in the namespace of
+        this draft of the Normative Types specification
+      </caption>
 
-<h2>Bibliography</h2>
-<dl>
-  <dt id="bib:pvdata">[bib:pvdata]</dt>
-    <dd><a href="http://epics-pvdata.sourceforge.net/literature.html#pvDataJava">EPICS
-      V4 Documentation page, Programmers' Reference Documentation section (pvData)</a>.
-    </dd>
-  <dt id="bib:pvaccess">[bib:pvaccess]</dt>
-  <dd><a href="http://epics-pvdata.sourceforge.net/literature.html#pvAccessJava">V4 Documentation page, Programmers' Reference Documentation section (pvAccess)</a>.
-  </dd>
-  <dt id="bib:epicsrecref">[bib:epicsrecref]</dt>
-  <dd><a
-    href="https://wiki-ext.aps.anl.gov/epics/index.php/RRM_3-14">EPICS
-    Reference Manual</a>, Philip Stanley, Janet Anderson, Marty Kraimer, APS,
-    <span style="white-space: nowrap;">https://wiki-ext.aps.anl.gov/epics/index.php/RRM_3-14.</span></dd>
-  <dt id="bib:epicsappdev">[bib:epicsappdev]</dt>
-      <dd><a href="http://www.aps.anl.gov/epics/base/R3-14/12-docs/AppDevGuide/">EPICS
-Input / Output Controller (IOC) Application Developer's Guide</a> Marty Kraimer, APS,
-	1994,  <span style="white-space: nowrap;">http://www.aps.anl.gov/epics/base/R3-14/12-docs/AppDevGuide/</span>.</dd>
-  <dt class="bib" id="bib:agg">bib:agg</dt>
-  <dd>Aggregate data, Wikipedia article, <a
-    href="http://en.wikipedia.org/wiki/Aggregate_data"><span style="white-space: nowrap;">http://en.wikipedia.org/wiki/Aggregate_data</span></a>.
-  </dd>
-  <dt class="bib" id="bib:rdbservice">bib:rdbservice</dt>
-  <dd>
-    rdbService, example EPICS V4 service, <a href="https://github.com/epics-base/exampleJava/tree/master/src/services/rdbService"><span style="white-space: nowrap;">https://github.com/epics-base/exampleJava/tree/master/src/services/rdbService</span></a>.
-  </dd>
-   <dt class="bib" id="bib:uri">bib:uri</dt>
-   <dd>Uniform Resource Identifiers (URI): Generic Syntax, <a href="http://www.ietf.org/rfc/rfc2396.txt" >http://www.ietf.org/rfc/rfc2396.txt</a>.
-   </dd>
-</dl>
+      <tr>
+        <th>Type Name</th>
 
+        <th>Version</th>
 
-</div>
+        <th>Depends on</th>
 
+        <th>Short Description</th>
+      </tr>
+
+      <tr>
+        <td>NTScalar</td>
+
+        <td>1.0</td>
+
+        <td>(none)</td>
+
+        <td>A single scalar value.</td>
+      </tr>
+
+      <tr>
+        <td>NTScalarArray</td>
+
+        <td>1.0</td>
+
+        <td>(none)</td>
+
+        <td>An array of scalar values of some single type.</td>
+      </tr>
+
+      <tr>
+        <td>NTEnum</td>
+
+        <td>1.0</td>
+
+        <td>(none)</td>
+
+        <td>An enumeration list and a value of that enumeration.</td>
+      </tr>
+
+      <tr>
+        <td>NTMatrix</td>
+
+        <td>1.0</td>
+
+        <td>(none)</td>
+
+        <td>A real number matrix.</td>
+      </tr>
+
+      <tr>
+        <td>NTURI</td>
+
+        <td>1.0</td>
+
+        <td>(none)</td>
+
+        <td>A structure for encapsulating a Uniform Resource Identifier
+        (URI).</td>
+      </tr>
+
+      <tr>
+        <td>NTNameValue</td>
+
+        <td>1.0</td>
+
+        <td>(none)</td>
+
+        <td>An array of scalar values where each element is named.</td>
+      </tr>
+
+      <tr>
+        <td>NTTable</td>
+
+        <td>1.0</td>
+
+        <td>(none)</td>
+
+        <td>A table of scalars, where each column may be of different
+        scalar array type</td>
+      </tr>
+
+      <tr>
+        <td>NTAttribute</td>
+
+        <td>1.0</td>
+
+        <td>(none)</td>
+
+        <td>A key-value pair, with optional string tags, where the value
+        is of any type.</td>
+      </tr>
+
+      <tr>
+        <td>NTMultiChannel</td>
+
+        <td>1.0</td>
+
+        <td>(none)</td>
+
+        <td>An array of PV names, their values, and metadata.</td>
+      </tr>
+
+      <tr>
+        <td>NTNDArray</td>
+
+        <td>1.0</td>
+
+        <td>NTAttribute 1.0</td>
+
+        <td>A pixel and metadata type, designed to encode a frame of data
+        from detectors and cameras.</td>
+      </tr>
+
+      <tr>
+        <td>NTContinuum</td>
+
+        <td>1.0</td>
+
+        <td>(none)</td>
+
+        <td>Expresses a sequence of data points in time or frequency
+        domain.</td>
+      </tr>
+
+      <tr>
+        <td>NTHistogram</td>
+
+        <td>1.0</td>
+
+        <td>(none)</td>
+
+        <td>An array of real number intervals, and their frequency counts.
+        Expresses a 1D histogram.</td>
+      </tr>
+
+      <tr>
+        <td>NTAggregate</td>
+
+        <td>1.0</td>
+
+        <td>(none)</td>
+
+        <td>A mean value, standard deviation, and other metadata.
+        Expresses the central tendency and dispersion of a set of data
+        points.</td>
+      </tr>
+    </table>
+
+    <p>For example, the type ID of a structure describing an NTScalar,
+    must be valued "epics:nt/NTScalar:1.0". The type ID of a structure
+    describing an NTNDArray, must be valued "epics:nt/NTNDArray:1.0".</p>
+
+    <p>Following drafts of this document MAY well correspond to the same
+    Namespace Name and Type Names as used in this draft. Also note that
+    the same namespace may well be used for a different collection of
+    types or Type Names, as this document matures.</p>
+
+    <h2>Bibliography</h2>
+
+    <dl>
+      <dt id="bib:pvdata">[bib:pvdata]</dt>
+
+      <dd><a href=
+      "http://epics-pvdata.sourceforge.net/literature.html#pvDataJava">EPICS
+      V4 Documentation page, Programmers' Reference Documentation section
+      (pvData)</a>.</dd>
+
+      <dt id="bib:pvaccess">[bib:pvaccess]</dt>
+
+      <dd><a href=
+      "http://epics-pvdata.sourceforge.net/literature.html#pvAccessJava">V4
+      Documentation page, Programmers' Reference Documentation section
+      (pvAccess)</a>.</dd>
+
+      <dt id="bib:epicsrecref">[bib:epicsrecref]</dt>
+
+      <dd><a href=
+      "https://wiki-ext.aps.anl.gov/epics/index.php/RRM_3-14">EPICS
+      Reference Manual</a>, Philip Stanley, Janet Anderson, Marty Kraimer,
+      APS, <span style=
+      "white-space: nowrap;">https://wiki-ext.aps.anl.gov/epics/index.php/RRM_3-14.</span></dd>
+
+      <dt id="bib:epicsappdev">[bib:epicsappdev]</dt>
+
+      <dd><a href=
+      "http://www.aps.anl.gov/epics/base/R3-14/12-docs/AppDevGuide/">EPICS
+      Input / Output Controller (IOC) Application Developer's Guide</a>
+      Marty Kraimer, APS, 1994, <span style=
+      "white-space: nowrap;">http://www.aps.anl.gov/epics/base/R3-14/12-docs/AppDevGuide/</span>.</dd>
+
+      <dt class="bib" id="bib:agg">bib:agg</dt>
+
+      <dd>Aggregate data, Wikipedia article, <a href=
+      "http://en.wikipedia.org/wiki/Aggregate_data"><span style=
+      "white-space: nowrap;">http://en.wikipedia.org/wiki/Aggregate_data</span></a>.</dd>
+
+      <dt class="bib" id="bib:rdbservice">bib:rdbservice</dt>
+
+      <dd>rdbService, example EPICS V4 service, <a href=
+      "https://github.com/epics-base/exampleJava/tree/master/src/services/rdbService">
+      <span style=
+      "white-space: nowrap;">https://github.com/epics-base/exampleJava/tree/master/src/services/rdbService</span></a>.</dd>
+
+      <dt class="bib" id="bib:uri">bib:uri</dt>
+
+      <dd>Uniform Resource Identifiers (URI): Generic Syntax, <a href=
+      "http://www.ietf.org/rfc/rfc2396.txt">http://www.ietf.org/rfc/rfc2396.txt</a>.</dd>
+    </dl>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
Clarify the normative aspects of the NTTable especially with respect to the labels field values and column array data fields - in response to email by D. Hickin.
